### PR TITLE
WorkingDirectory and non-interactive Start-ProcessWith -Credential support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,9 +12,6 @@ on:
     types:
     - published
 
-  schedule:
-  - cron: 0 9 * * *
-
 env:
   DOTNET_CLI_TELEMETRY_OPTOUT: 1
   POWERSHELL_TELEMETRY_OPTOUT: 1
@@ -30,9 +27,18 @@ jobs:
     - name: Check out repository
       uses: actions/checkout@v2
 
-    - name: Build module
+    - name: Build module - Debug
       shell: pwsh
       run: ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Build
+      if: ${{ env.BUILD_CONFIGURATION == 'Debug' }}
+
+    - name: Build module - Publish
+      shell: pwsh
+      run: ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Build
+      if: ${{ env.BUILD_CONFIGURATION == 'Release' }}
+      env:
+        PSMODULE_SIGNING_CERT: ${{ secrets.PSMODULE_SIGNING_CERT }}
+        PSMODULE_SIGNING_CERT_PASSWORD: ${{ secrets.PSMODULE_SIGNING_CERT_PASSWORD }}
 
     - name: Capture PowerShell Module
       uses: actions/upload-artifact@v2
@@ -73,7 +79,7 @@ jobs:
       run: |
         $manifestItem = Get-Item ([IO.Path]::Combine('module', '*.psd1'))
         $moduleName = $manifestItem.BaseName
-        $manifest = Test-ModuleManifest -Path $manifestItem.FullName -ErrorAction Stop -WarningAction Ignore
+        $manifest = Test-ModuleManifest -Path $manifestItem.FullName -ErrorAction SilentlyContinue -WarningAction Ignore
 
         $destPath = [IO.Path]::Combine('output', $moduleName, $manifest.Version)
         if (-not (Test-Path -LiteralPath $destPath)) {
@@ -88,7 +94,7 @@ jobs:
     - name: Run Tests
       shell: pwsh
       run: |
-        & "${{ matrix.info.psversion }}" -NoProfile -File ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Test -Elevate
+        & "${{ matrix.info.psversion }}" -NoProfile -File ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Test -Elevated
         exit $LASTEXITCODE
 
     - name: Upload Test Results
@@ -133,6 +139,6 @@ jobs:
         dotnet nuget push '*.nupkg'
         --api-key $env:PSGALLERY_TOKEN
         --source 'https://www.powershellgallery.com/api/v2/package'
-        --no-symbols true
+        --no-symbols
       env:
         PSGALLERY_TOKEN: ${{ secrets.PSGALLERY_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog for ProcessEx
 
+## v0.2.0 - TBD
+
+* Added `WorkingDirectory` to the `ProcessInfo` object returned by `Get-ProcessEx`
+* Fixed `Start-ProcessWith ... -Credential $cred` when running in a non-interactive session
+  * Previous this set the `lpDesktop` field in the startup info to `NULL` but due to the Windows rules for non-interactive sessions this failed
+  * By explicitly setting the value to the current station/desktop this step will now work
+
 ## v0.1.0 - 2021-12-06
 
 * Initial version of the `ProcessEx` module

--- a/docs/en-US/Get-ProcessEx.md
+++ b/docs/en-US/Get-ProcessEx.md
@@ -95,6 +95,8 @@ The `ProcessInfo` of the opened process. This contains properties like the proce
 
 - `CommandLine` - The command line used to start the process
 
+- `WorkingDirectory` - The working/current directory of the process
+
 - `Process` - The `SafeHandle` of the process retrieved
 
 - `Thread` - This is not set in the output from `Get-ProcessEx` and should be ignored

--- a/docs/en-US/Start-ProcessEx.md
+++ b/docs/en-US/Start-ProcessEx.md
@@ -348,6 +348,8 @@ This object contains the following properties:
 
 - `CommandLine` - The command line used to start the process
 
+- `WorkingDirectory` - The working/current directory of the process
+
 - `Process` - The `SafeHandle` of the process created
 
 - `Thread` - The `SafeHandle` of the main thread

--- a/docs/en-US/Start-ProcessWith.md
+++ b/docs/en-US/Start-ProcessWith.md
@@ -392,6 +392,8 @@ This object contains the following properties:
 
 - `CommandLine` - The command line used to start the process
 
+- `WorkingDirectory` - The working/current directory of the process
+
 - `Process` - The `SafeHandle` of the process created
 
 - `Thread` - The `SafeHandle` of the main thread

--- a/module/ProcessEx.psd1
+++ b/module/ProcessEx.psd1
@@ -14,7 +14,7 @@
     RootModule = 'ProcessEx.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.1.0'
+    ModuleVersion = '0.2.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/requirements-dev.psd1
+++ b/requirements-dev.psd1
@@ -1,7 +1,7 @@
 @{
-    InvokeBuild = '5.8.5'
-    Pester = '5.3.1'
+    InvokeBuild = '5.9.12'
+    Pester = '5.3.3'
     platyPS = '0.14.2'
     PSPrivilege = '0.2.0'
-    PSScriptAnalyzer = '1.20.0'
+    PSScriptAnalyzer = '1.21.0'
 }

--- a/src/Native/Ntdll.cs
+++ b/src/Native/Ntdll.cs
@@ -113,7 +113,9 @@ namespace ProcessEx.Native
         public struct RTL_USER_PROCESS_PARAMETERS
         {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)] public byte[] Reserved1;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)] public IntPtr[] Reserved2;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 5)] public IntPtr[] Reserved2;
+            public UNICODE_STRING CurrentDirectoryPath;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)] public IntPtr[] Reserved3;
             public UNICODE_STRING ImagePathName;
             public UNICODE_STRING CommandLine;
             public IntPtr Environment; // Undocumented but comes after CommandLine
@@ -123,7 +125,9 @@ namespace ProcessEx.Native
         public struct RTL_USER_PROCESS_PARAMETERS_32
         {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)] public byte[] Reserved1;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)] public Int32[] Reserved2;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 5)] public Int32[] Reserved2;
+            public UNICODE_STRING_32 CurrentDirectoryPath;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)] public Int32[] Reserved3;
             public UNICODE_STRING_32 ImagePathName;
             public UNICODE_STRING_32 CommandLine;
             public Int32 Environment; // Undocumented but comes after CommandLine
@@ -133,7 +137,9 @@ namespace ProcessEx.Native
         public struct RTL_USER_PROCESS_PARAMETERS_64
         {
             [MarshalAs(UnmanagedType.ByValArray, SizeConst = 16)] public byte[] Reserved1;
-            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 10)] public Int64[] Reserved2;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 5)] public Int64[] Reserved2;
+            public UNICODE_STRING_64 CurrentDirectoryPath;
+            [MarshalAs(UnmanagedType.ByValArray, SizeConst = 3)] public Int64[] Reserved3;
             public UNICODE_STRING_64 ImagePathName;
             public UNICODE_STRING_64 CommandLine;
             public Int64 Environment; // Undocumented but comes after CommandLine

--- a/src/ProcessEx.csproj
+++ b/src/ProcessEx.csproj
@@ -6,10 +6,6 @@
     <LangVersion>8.0</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-
-    <!--Used in test build scripts-->
-    <PSWinFramework>net472</PSWinFramework>
-    <PSFramework>netcoreapp3.1</PSFramework>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">

--- a/src/ProcessInfo.cs
+++ b/src/ProcessInfo.cs
@@ -10,6 +10,7 @@ namespace ProcessEx
     public class ProcessInfo
     {
         private string? _executable;
+        private string? _workingDirectory;
         private string? _cmdLine;
         private int _pid;
         private int _tid;
@@ -23,6 +24,15 @@ namespace ProcessEx
             {
                 _executable ??= Kernel32.QueryFullProcessImageName(Process, Helpers.QueryImageNameFlags.NONE);
                 return _executable;
+            }
+        }
+
+        public string WorkingDirectory
+        {
+            get
+            {
+                _workingDirectory ??= ProcessEnvironmentBlock.ProcessParameters.WorkingDirectory;
+                return _workingDirectory;
             }
         }
 
@@ -247,6 +257,7 @@ namespace ProcessEx
 
     internal class ProcessParameters
     {
+        public string WorkingDirectory { get; set; }
         public string ImagePathName { get; set; }
         public string CommandLine { get; set; }
         public Dictionary<string, string> Environment { get; set; }
@@ -257,6 +268,7 @@ namespace ProcessEx
                 (IntPtr)Marshal.SizeOf(typeof(Helpers.RTL_USER_PROCESS_PARAMETERS)));
             var pp = Marshal.PtrToStructure<Helpers.RTL_USER_PROCESS_PARAMETERS>(buffer.DangerousGetHandle());
 
+            WorkingDirectory = ConvertUnicodeString(process, pp.CurrentDirectoryPath);
             ImagePathName = ConvertUnicodeString(process, pp.ImagePathName);
             CommandLine = ConvertUnicodeString(process, pp.CommandLine);
             Environment = GetEnvironment(process, pp.Environment);
@@ -268,6 +280,7 @@ namespace ProcessEx
                 (IntPtr)Marshal.SizeOf(typeof(Helpers.RTL_USER_PROCESS_PARAMETERS_32)));
             var pp = Marshal.PtrToStructure<Helpers.RTL_USER_PROCESS_PARAMETERS_32>(buffer.DangerousGetHandle());
 
+            WorkingDirectory = ConvertUnicodeString(process, pp.CurrentDirectoryPath);
             ImagePathName = ConvertUnicodeString(process, pp.ImagePathName);
             CommandLine = ConvertUnicodeString(process, pp.CommandLine);
             Environment = GetEnvironment(process, (IntPtr)pp.Environment);
@@ -279,6 +292,7 @@ namespace ProcessEx
                 Marshal.SizeOf(typeof(Helpers.RTL_USER_PROCESS_PARAMETERS_64)));
             var pp = Marshal.PtrToStructure<Helpers.RTL_USER_PROCESS_PARAMETERS_64>(buffer.DangerousGetHandle());
 
+            WorkingDirectory = ConvertUnicodeString(process, pp.CurrentDirectoryPath);
             ImagePathName = ConvertUnicodeString(process, pp.ImagePathName);
             CommandLine = ConvertUnicodeString(process, pp.CommandLine);
             Environment = GetEnvironment(process, pp.Environment);

--- a/tests/ProcessEx.Tests.ps1
+++ b/tests/ProcessEx.Tests.ps1
@@ -54,6 +54,7 @@ Describe "Get-ProcessEx" {
                 $actual.Executable | Should -Be "C:\Windows\SysWow64\WindowsPowerShell\v1.0\powershell.exe"
             }
             $actual.CommandLine | Should -Be $procParams.CommandLine
+            $actual.WorkingDirectory | Should -Be "$([System.Environment]::CurrentDirectory)\"
             $actual.Environment.Count | Should -Be 2
             $actual.Environment.AAA | Should -Be "aaa"
             $actual.Environment.ZZZ | Should -Be "zzz"
@@ -85,6 +86,7 @@ Describe "Get-ProcessEx" {
                         AAA = "aaa"
                         ZZZ = "zzz"
                     }
+                    WorkingDirectory = "C:\Windows\TEMP"
                     PassThru = $true
                 }
 
@@ -100,6 +102,7 @@ Describe "Get-ProcessEx" {
 
             $actual.Executable | Should -Be  $pwshNative
             $actual.CommandLine | Should -Be $cmdLine
+            $actual.WorkingDirectory | Should -Be "C:\Windows\TEMP\"
             $actual.Environment.Count | Should -Be 2
             $actual.Environment.AAA | Should -Be "aaa"
             $actual.Environment.ZZZ | Should -Be "zzz"
@@ -123,6 +126,7 @@ Describe "Get-ProcessEx" {
                         AAA = "aaa"
                         ZZZ = "zzz"
                     }
+                    WorkingDirectory = "C:\Windows\TEMP\"
                     PassThru = $true
                 }
 
@@ -138,6 +142,7 @@ Describe "Get-ProcessEx" {
 
             $actual.Executable | Should -Be  $pwsh32
             $actual.CommandLine | Should -Be $cmdLine
+            $actual.WorkingDirectory | Should -Be "C:\Windows\TEMP\"
             $actual.Environment.Count | Should -Be 2
             $actual.Environment.AAA | Should -Be "aaa"
             $actual.Environment.ZZZ | Should -Be "zzz"
@@ -161,6 +166,7 @@ Describe "Get-ProcessEx" {
                         AAA = "aaa"
                         ZZZ = "zzz"
                     }
+                    WorkingDirectory = "C:\Windows\TEMP"
                     PassThru = $true
                 }
 
@@ -176,6 +182,7 @@ Describe "Get-ProcessEx" {
 
             $actual.Executable | Should -Be "C:\Windows\SysWow64\WindowsPowerShell\v1.0\powershell.exe"
             $actual.CommandLine | Should -Be $cmdLine
+            $actual.WorkingDirectory | Should -Be "C:\Windows\TEMP\"
             $actual.Environment.Count | Should -Be 2
             $actual.Environment.AAA | Should -Be "aaa"
             $actual.Environment.ZZZ | Should -Be "zzz"
@@ -199,6 +206,7 @@ Describe "Get-ProcessEx" {
                         AAA = "aaa"
                         ZZZ = "zzz"
                     }
+                    WorkingDirectory = "C:\Windows\TEMP"
                     PassThru = $true
                 }
 
@@ -214,6 +222,7 @@ Describe "Get-ProcessEx" {
 
             $actual.Executable | Should -Be $pwshNative
             $actual.CommandLine | Should -Be $cmdLine
+            $actual.WorkingDirectory | Should -Be "C:\Windows\TEMP\"
             $actual.Environment.Count | Should -Be 2
             $actual.Environment.AAA | Should -Be "aaa"
             $actual.Environment.ZZZ | Should -Be "zzz"


### PR DESCRIPTION
Updates the build scripts and added the `WorkingDirectory` property to the `ProcessInfo` output object.