### PR TITLE
Add JobList to New-StartupInfo

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -23,7 +23,7 @@
             "type": "shell",
             "args": [
                 "-Command",
-                "Import-Module ${workspaceFolder}/output/ProcessEx; Import-Module platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
+                "Import-Module ${workspaceFolder}/output/ProcessEx; Import-Module ${workspaceFolder}/tools/Modules/platyPS; Update-MarkdownHelpModule ${workspaceFolder}/docs/en-US -AlphabeticParamsOrder -RefreshModulePage -UpdateInputOutput"
             ],
             "problemMatcher": [],
             "dependsOn": [

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog for ProcessEx
 
+## v0.3.0 - TBD
+
+* Added `JobList` to `New-StartupInfo`
+  * This provides an easier way to specify the jobs a new process is a member of
+  * Requires Windows 10 or Server 2016
+
 ## v0.2.0 - 2022-10-02
 
 * Added `WorkingDirectory` to the `ProcessInfo` object returned by `Get-ProcessEx`

--- a/docs/en-US/Copy-HandleToProcess.md
+++ b/docs/en-US/Copy-HandleToProcess.md
@@ -170,8 +170,7 @@ The handles to copy to the target process.
 ## OUTPUTS
 
 ### ProcessEx.Native.SafeDuplicateHandle
-The duplicated handle that can be used in the target process.
-Use `[string]$out.DangerousGetHandle()` to get a serialzied representation of the handle to pass to the target process.
+The duplicated handle that can be used in the target process. Use `[string]$out.DangerousGetHandle()` to get a serialzied representation of the handle to pass to the target process.
 
 ## NOTES
 

--- a/docs/en-US/Get-ProcessEnvironment.md
+++ b/docs/en-US/Get-ProcessEnvironment.md
@@ -65,8 +65,7 @@ The `Process` object, process id, or name.
 ## OUTPUTS
 
 ### System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
-A dictionary containing the environment variables.
-Each key is case insensitive as environment variables on Windows are case insensitive.
+A dictionary containing the environment variables. Each key is case insensitive as environment variables on Windows are case insensitive.
 
 ## NOTES
 This function uses undocumented APIs to retrieve the environment variables of other processes.

--- a/docs/en-US/Get-StartupInfo.md
+++ b/docs/en-US/Get-StartupInfo.md
@@ -40,8 +40,7 @@ This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable
 ## OUTPUTS
 
 ### ProcessEx.StartupInfo
-The `StartupInfo` value for the current process.
-Any of the extended thread attribute values, like `ParentProcess`, `ConPTY`, and `InheritedHandle` will not be set as they are used only for creating new processes.
+The `StartupInfo` value for the current process. Any of the extended thread attribute values, like `ParentProcess`, `ConPTY`, and `InheritedHandle` will not be set as they are used only for creating new processes.
 
 ## NOTES
 

--- a/docs/en-US/Get-TokenEnvironment.md
+++ b/docs/en-US/Get-TokenEnvironment.md
@@ -62,8 +62,7 @@ The access tokens to build the environment variables from.
 ## OUTPUTS
 
 ### System.Collections.Generic.Dictionary`2[[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e],[System.String, System.Private.CoreLib, Version=6.0.0.0, Culture=neutral, PublicKeyToken=7cec85d7bea7798e]]
-A dictionary containing the environment variables.
-Each key is case insensitive as environment variables on Windows are case insensitive.
+A dictionary containing the environment variables. Each key is case insensitive as environment variables on Windows are case insensitive.
 
 ## NOTES
 

--- a/docs/en-US/New-StartupInfo.md
+++ b/docs/en-US/New-StartupInfo.md
@@ -17,8 +17,8 @@ Create a StartupInfo object for creating a process.
 New-StartupInfo [-Desktop <String>] [-Title <String>] [-Position <Coordinates>] [-WindowSize <Size>]
  [-CountChars <Size>] [-FillAttribute <ConsoleFill>] [-Flags <StartupInfoFlags>] [-WindowStyle <WindowStyle>]
  [-Reserved <String>] [-Reserved2 <Byte[]>] [-StandardInput <SafeHandle>] [-StandardOutput <SafeHandle>]
- [-StandardError <SafeHandle>] [-InheritedHandle <SafeHandle[]>] [-ParentProcess <ProcessIntString>]
- [<CommonParameters>]
+ [-StandardError <SafeHandle>] [-InheritedHandle <SafeHandle[]>] [-JobList <SafeHandle[]>]
+ [-ParentProcess <ProcessIntString>] [<CommonParameters>]
 ```
 
 ### ConPTY
@@ -26,7 +26,7 @@ New-StartupInfo [-Desktop <String>] [-Title <String>] [-Position <Coordinates>] 
 New-StartupInfo [-Desktop <String>] [-Title <String>] [-Position <Coordinates>] [-WindowSize <Size>]
  [-CountChars <Size>] [-FillAttribute <ConsoleFill>] [-Flags <StartupInfoFlags>] [-WindowStyle <WindowStyle>]
  [-Reserved <String>] [-Reserved2 <Byte[]>] [-ConPTY <SafeHandle>] [-InheritedHandle <SafeHandle[]>]
- [-ParentProcess <ProcessIntString>] [<CommonParameters>]
+ [-JobList <SafeHandle[]>] [-ParentProcess <ProcessIntString>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -183,6 +183,24 @@ When `-ParentProcess` is not set, all these handles will be changed to an inheri
 When `-ParentProcess` is set then these handles need to be a valid handle in the parent process itself.
 Use `Copy-HandleToProcess` with `-Inherit` and `-OwnHandle` to open them in the parent process for it to be a valid handle for inheritance by the new process.
 Not having an inherited handle in the parent process will cause a failure when trying to start the process.
+This will not work with `Start-ProcessWith` due to the restrictions in the underlying APIs it calls.
+
+```yaml
+Type: SafeHandle[]
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -JobList
+A list of job handles to be assigned to the child process.
+If omitted then the child will be assigned the job of the calling process if it is part of any job.
+This requires Windows 10, Server 2016, or newer to be used.
 This will not work with `Start-ProcessWith` due to the restrictions in the underlying APIs it calls.
 
 ```yaml

--- a/module/ProcessEx.psd1
+++ b/module/ProcessEx.psd1
@@ -14,7 +14,7 @@
     RootModule = 'ProcessEx.psm1'
 
     # Version number of this module.
-    ModuleVersion = '0.2.0'
+    ModuleVersion = '0.3.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/requirements-dev.psd1
+++ b/requirements-dev.psd1
@@ -1,6 +1,6 @@
 @{
-    InvokeBuild = '5.9.12'
-    Pester = '5.3.3'
+    InvokeBuild = '5.10.2'
+    Pester = '5.4.0'
     platyPS = '0.14.2'
     PSPrivilege = '0.2.0'
     PSScriptAnalyzer = '1.21.0'

--- a/src/Commands/ProcessWith.cs
+++ b/src/Commands/ProcessWith.cs
@@ -132,6 +132,12 @@ namespace ProcessEx.Commands
                 WriteError(new ErrorRecord(ex, "WithAndInheritedHandles", ErrorCategory.InvalidArgument, null));
                 return;
             }
+            if (StartupInfo.JobList.Length > 0)
+            {
+                ArgumentException ex = new ArgumentException("Start-ProcessWith cannot be used with JobList");
+                WriteError(new ErrorRecord(ex, "WithAndJobList", ErrorCategory.InvalidArgument, null));
+                return;
+            }
             if (StartupInfo.ParentProcess != 0)
             {
                 ArgumentException ex = new ArgumentException("Start-ProcessWith cannot be used with ParentProcess");

--- a/src/Commands/StartupInfo.cs
+++ b/src/Commands/StartupInfo.cs
@@ -103,6 +103,9 @@ namespace ProcessEx.Commands
         public SafeHandle[] InheritedHandle = Array.Empty<SafeHandle>();
 
         [Parameter()]
+        public SafeHandle[] JobList = Array.Empty<SafeHandle>();
+
+        [Parameter()]
         public ProcessIntString? ParentProcess;
 
         protected override void ProcessRecord()
@@ -163,6 +166,7 @@ namespace ProcessEx.Commands
                 StandardError = StandardError ?? nullHandle,
                 ConPTY = ConPTY ?? nullHandle,
                 InheritedHandles = InheritedHandle,
+                JobList = JobList,
                 ParentProcess = ParentProcess?.ProcessId ?? 0,
                 ParentProcessHandle = ParentProcess?.ProcessHandle,
             });

--- a/tests/ProcessEx.Tests.ps1
+++ b/tests/ProcessEx.Tests.ps1
@@ -688,6 +688,30 @@ Describe "Start-ProcessEx" {
         }
     }
 
+    It "Associated with custom jobs" {
+        $job1 = $job2 = $job3 = $proc = $null
+        try {
+            $job1 = [ProcessExTests.Native]::CreateJobObject("ProcessEx-Job1")
+            $job2 = [ProcessExTests.Native]::CreateJobObject("ProcessEx-Job2")
+            $job3 = [ProcessExTests.Native]::CreateJobObject("ProcessEx-Job3")
+
+            $si = New-StartupInfo -JobList $job1, $job2
+            $proc = Start-ProcessEx -CommandLine powershell.exe -StartupInfo $si -PassThru
+
+            [ProcessExTests.Native]::IsProcessInJob($proc.Process, $job1) | Should -BeTrue
+            [ProcessExTests.Native]::IsProcessInJob($proc.Process, $job2) | Should -BeTrue
+            [ProcessExTests.Native]::IsProcessInJob($proc.Process, $job3) | Should -BeFalse
+        }
+        finally {
+            if ($proc) {
+                $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
+            if ($job1) { $job1.Dispose() }
+            if ($job2) { $job2.Dispose() }
+            if ($job3) { $job3.Dispose() }
+        }
+    }
+
     It "Parent process" {
         $parentProc = Start-ProcessEx powershell.exe -PassThru
         try {
@@ -1615,6 +1639,30 @@ Describe "Start-ProcessEx with Token" -Skip:(Get-ProcessPrivilege -Name SeAssign
             $pipe1.Dispose()
             $pipe2.Dispose()
             $pipe3.Dispose()
+        }
+    }
+
+    It "Associated with custom jobs" {
+        $job1 = $job2 = $job3 = $proc = $null
+        try {
+            $job1 = [ProcessExTests.Native]::CreateJobObject("ProcessEx-Job1")
+            $job2 = [ProcessExTests.Native]::CreateJobObject("ProcessEx-Job2")
+            $job3 = [ProcessExTests.Native]::CreateJobObject("ProcessEx-Job3")
+
+            $si = New-StartupInfo -JobList $job1, $job2
+            $proc = Start-ProcessEx -CommandLine powershell.exe -StartupInfo $si -PassThru -Token $token
+
+            [ProcessExTests.Native]::IsProcessInJob($proc.Process, $job1) | Should -BeTrue
+            [ProcessExTests.Native]::IsProcessInJob($proc.Process, $job2) | Should -BeTrue
+            [ProcessExTests.Native]::IsProcessInJob($proc.Process, $job3) | Should -BeFalse
+        }
+        finally {
+            if ($proc) {
+                $proc | Stop-Process -Force -ErrorAction SilentlyContinue
+            }
+            if ($job1) { $job1.Dispose() }
+            if ($job2) { $job2.Dispose() }
+            if ($job3) { $job3.Dispose() }
         }
     }
 

--- a/tests/ProcessWith.Tests.ps1
+++ b/tests/ProcessWith.Tests.ps1
@@ -624,6 +624,20 @@ Describe "Start-ProcessWith" {
         }
     }
 
+    It "Fails with job list" {
+        $job = [ProcessExTests.Native]::CreateJobObject("ProcessEx-Job")
+        try {
+            $err = $null
+            $si = New-StartupInfo -JobList $job
+            Start-ProcessWith pwsh -StartupInfo $si -Token $token -ErrorAction SilentlyContinue -ErrorVariable err
+            $err.Count | Should -Be 1
+            [string]$err[0] | Should -Be "Start-ProcessWith cannot be used with JobList"
+        }
+        finally {
+            $job.Dispose()
+        }
+    }
+
     It "Fails with parent process" {
         $si = New-StartupInfo -ParentProcess $pid
         $err = $null

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -104,6 +104,20 @@ namespace ProcessExTests
             return handle;
         }
 
+        [DllImport("Kernel32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        private static extern SafeProcessHandle CreateJobObjectW(
+            IntPtr lpJobAttributes,
+            string lpName);
+
+        public static SafeProcessHandle CreateJobObject(string name)
+        {
+            SafeProcessHandle job = CreateJobObjectW(IntPtr.Zero, name);
+            if (job.DangerousGetHandle() == IntPtr.Zero)
+                throw new Win32Exception();
+
+            return job;
+        }
+
         [DllImport("Userenv.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern bool DeleteProfileW(
             string lpSidString,
@@ -276,6 +290,23 @@ namespace ProcessExTests
         {
             if (!NativeImpersonateLoggedOnUser(token))
                 throw new Win32Exception();
+        }
+
+        [DllImport("Kernel32.dll", EntryPoint = "IsProcessInJob", SetLastError = true)]
+        private static extern bool NativeIsProcessInJob(
+            SafeHandle ProcessHandle,
+            SafeHandle JobHandle,
+            out bool Result);
+
+        public static bool IsProcessInJob(SafeHandle process, SafeHandle job)
+        {
+            bool res;
+            if (!NativeIsProcessInJob(process, job, out res))
+            {
+                throw new Win32Exception();
+            }
+
+            return res;
         }
 
         [DllImport("Userenv.dll", CharSet = CharSet.Unicode, SetLastError = true)]


### PR DESCRIPTION
Adds the -JobList parameter to New-StartupInfo that allows the caller to specify the job(s) the new process should be associated with. This corresponds to the PROC_THREAD_ATTRIBUTE_JOB_LIST proc thread attribute entry.