### PR TITLE
Added Invoke-Process* cmdlets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -363,3 +363,4 @@ FodyWeavers.xsd
 
 ### Custom entries ###
 output/
+tools/Microsoft

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -20,6 +20,21 @@
             "console": "externalTerminal",
         },
         {
+            "name": "Windows PowerShell launch",
+            "type": "clr",
+            "request": "launch",
+            "program": "powershell",
+            "args": [
+                "-NoExit",
+                "-NoProfile",
+                "-Command",
+                "Import-Module ./output/ProcessEx"
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "externalTerminal",
+        },
+        {
             "name": "PowerShell Launch Current File",
             "type": "PowerShell",
             "request": "launch",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## v0.4.0 - TBD
 
+* Added `Invoke-ProcessWith` and `Invoke-ProcessEx` to invoke a process and capture the output like a normal call operator
+* Added `-ArgumentEscaping` to `ConvertTo-EscapedArgument` with the ability to escape MSI style properties
+
 ## v0.3.0 - 2023-02-15
 
 * Added `JobList` to `New-StartupInfo`

--- a/docs/en-US/ConvertTo-EscapedArgument.md
+++ b/docs/en-US/ConvertTo-EscapedArgument.md
@@ -13,23 +13,82 @@ Escape argument for the command line.
 ## SYNTAX
 
 ```
-ConvertTo-EscapedArgument [-InputObject] <String[]> [-ProgressAction <ActionPreference>] [<CommonParameters>]
+ConvertTo-EscapedArgument [-ArgumentEscaping <ArgumentEscapingMode>] [-InputObject] <String[]>
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
 Escapes the arguments supplied so they are seen as a distinct argument in the command line string.
-The escaping logic is based on the Windows C argument standard rules but some applications may not use this standard.
+The default escaping logic is based on the Windows C argument standard rules but some applications may not use this standard.
+Using `-ArgumentEscaping Msi` the escaping logic can be set to escape MSI property keys and values alongside the C rules.
+When escaping according to the `Msi` rules a `PROPERTY=value` is escaped as follows:
+
++ The `PROPERTY=` is kept as is
++ The `value` is quoted if it contains whitespace, double quotes, or is empty
++ The `value` will double up on any double quotes
+
+If the argument does not match the MSI `PROPERTY=value` format, it is escaped according to the normal C rules.
+An MSI property name must begin with either a litter or an underscore followed by letters, numerals, underscores, or periods.
 
 ## EXAMPLES
 
-### Example 1
+### Example 1: Escape value using C style rules
 ```powershell
 PS C:\> $arguments = ConvertTo-EscapedArgument $argumentList
 ```
 
 Escapes each argument in `$argumentList` for use with the raw CreateProcess command value.
 
+### Example 2: Escape MSI style properties
+```powershell
+PS C:\> @(
+    'FOO'
+    'A=value'
+    'B='
+    'C=""'
+    'D=value with space'
+    'E=value with "quotes" and spaces'
+    '1F=invalid prop wont be escaped on MSI rules'
+    'C:\path with space'
+) | ConvertTo-EscapedArgument -ArgumentEscaping Msi
+
+# FOO
+# A=value
+# B=""
+# C=""""""
+# D="value with space"
+# E="value with ""quotes"" and spaces"
+# "1F=invalid prop wont be escaped on MSI rules"
+# "C:\path with space"
+```
+
+Escaped each argument using the `Msi` ruleset.
+Any argument that does not match the MSI `PROPERTY=value` format will be escaped based on the C style rules.
+Some further notes
+
++ `B=` becomes `B=""` as a way to unset an MSI property
++ `C=""` becomes `C=""""""` as the `""` as both doubled up and the value is then quoted
++ `1F=invalid ...` is not treated as an MSI property because they cannot start with numbers
+
 ## PARAMETERS
+
+### -ArgumentEscaping
+The escaping rules to use.
+The default `Standard` will use the C escaping rules.
+The `Msi` ruleset will escape MSI property names and values, otherwise falls back to the standard C escaping rules.
+The `Raw` will not escape any value and return it as is.
+
+```yaml
+Type: ArgumentEscapingMode
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: Standard
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -InputObject
 The arguments to escape.
@@ -80,3 +139,5 @@ The escaped arguments.
 
 [Parsing C Command-Line Arguments](https://docs.microsoft.com/en-us/cpp/c-language/parsing-c-command-line-arguments?view=msvc-170)
 [Everyone quotes command line arguments the wrong way](https://docs.microsoft.com/en-us/archive/blogs/twistylittlepassagesallalike/everyone-quotes-command-line-arguments-the-wrong-way)
+[MSI command line options](https://learn.microsoft.com/en-us/windows/win32/msi/command-line-options)
+[MSI property name restrictions](https://learn.microsoft.com/en-us/windows/win32/msi/restrictions-on-property-names)

--- a/docs/en-US/Invoke-ProcessEx.md
+++ b/docs/en-US/Invoke-ProcessEx.md
@@ -1,0 +1,588 @@
+---
+external help file: ProcessEx.dll-Help.xml
+Module Name: ProcessEx
+online version: github.com/jborean93/ProcessEx/blob/main/docs/en-US/Invoke-ProcessEx.md
+schema: 2.0.0
+---
+
+# Invoke-ProcessEx
+
+## SYNOPSIS
+Invoke a process inline and capture the output like the call operator.
+
+## SYNTAX
+
+### FilePath (Default)
+```
+Invoke-ProcessEx [-DisableInheritance] [-Token <SafeHandle>] [-UseConPTY] [-ConPTYHeight <Int16>]
+ [-ConPTYWidth <Int16>] [-UseNewEnvironment] [-FilePath] <String> [-ArgumentList <String[]>]
+ [-ArgumentEscaping <ArgumentEscapingMode>] [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>]
+ [-Environment <IDictionary>] [-InputObject <Object>] [-InputEncoding <EncodingOrByteStream>]
+ [-OutputEncoding <EncodingOrByteStream>] [-RedirectStdout <StdioStreamTarget>]
+ [-RedirectStderr <StdioStreamTarget>] [-Raw] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### CommandLine
+```
+Invoke-ProcessEx [-DisableInheritance] [-Token <SafeHandle>] [-UseConPTY] [-ConPTYHeight <Int16>]
+ [-ConPTYWidth <Int16>] [-UseNewEnvironment] -CommandLine <String> [-ApplicationName <String>]
+ [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>] [-Environment <IDictionary>] [-InputObject <Object>]
+ [-InputEncoding <EncodingOrByteStream>] [-OutputEncoding <EncodingOrByteStream>]
+ [-RedirectStdout <StdioStreamTarget>] [-RedirectStderr <StdioStreamTarget>] [-Raw]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Invokes a process, waits for it to finish and returns the output back to PowerShell.
+This is like the builtin call operator `& whoami` but with a few more features.
+Some features it offers over the call operator are:
+
++ It can capture the raw bytes of the stdout/stderr streams
++ You can control the encoding used to pipe strings into and decode out of the process through a parameter rather than a global value
++ You can capture the raw bytes of the process rather than decode it to a string
++ The command can either be run from a single command line string or escaped through an array of arguments
++ You can run it as another user through the `-Token` parameter
++ You can have access to extended startup info attributes like a parent process, ConPTY, explicit handle inheritance, etc
+
+Some things that this cmdlet cannot do or is not designed for
+
++ Starting an interactive process - the output can be set to a console but it is not the default
++ Dealing with env var changes between `pwsh.exe` and `powershell.exe`, use `-UseNewEnvironment` or an explicit `-Environment` block to handle this better
++ Using the PowerShell minishell `powershell { ... }` does not work
+
+The cmdlet is also exposed through the `procex` alias for easier interactive use.
+
+It can be used to run a process as another user through the `-Token` parameter but requires the caller to have the `SeAssignPrimaryTokenPrivilege` and `SeIncreaseQuotaPrivilege` privileges which is not granted to an Administrator by default.
+Like the normal call operator, when a process is complete, the `$LASTEXITCODE` variable will be set to the exit code of the process.
+
+By default the cmdlet is set to capture stdout lines in the output stream and stderr lines in the error stream.
+If `$ErrorActionPreference = 'Stop'` or `-ErrorAction Stop` is set on the cmdlet, any stderr lines will terminate the statement.
+Either explicitly set `-ErrorAction Continue` or use `-RedirectStderr` to something else to change this behaviour.
+
+Use [Invoke-ProcessWith](./Invoke-ProcessWith.md) which exposes a similar set of options but without the extra privilege requirement.
+
+Use [Start-ProcessEx](./Start-ProcessEx.md) to invoke a process in the background.
+
+## EXAMPLES
+
+### Example 1: Invokes a process and captures the output
+```powershell
+PS C:\> $out = Invoke-ProcessEx pwsh.exe '-Command' '"test"'
+```
+
+Invokes `pwsh.exe -Command "test"` and captures the output into the `$out` var.
+The encoding used defaults to the `[Console]::OutputEncoding` encoding but can be configured with `-OutputEncoding`.
+
+### Example 2: Invokes a process and pipe data into it
+```powershell
+PS C:\> 'foo', 'bar' | Invoke-ProcessEx pwsh.exe '-Command' '$input'
+```
+
+Runs the binary `pwsh.exe` and pipes in the strings `foo` and `bar` as lines.
+The command will just output it back but this shows how strings are piped into the new process.
+
+### Example 3: Invoke binary data into a new process
+```powershell
+PS C:\> , (Get-Content -Path something.dll -AsByteStream -Raw) | Invoke-ProcessEx hexdump
+```
+
+Pipes in raw bytes to the `hexdump` executable.
+These raw bytes are not subject to `-InputEncoding` and are written as is.
+The command that wraps `, (Get-Content ...)` is not needed but makes writing the input bytes simpler and more efficient.
+If running on PowerShell 5.1 change `-AsByteStream` to `-Encoding Bytes`.
+
+### Example 4: Run binary with custom output encoding
+```powershell
+PS C:\> Invoke-ProcessEx winget list -OutputEncoding UTF8
+```
+
+Runs the command `winget list` and captures the raw output using the UTF-8 encoding rather than `[Console]::OutputEncoding`.
+This is useful when interacting with commands that write with a codepage that does not use the console codepage.
+
+### Example 5: Redirect stderr to the output stream
+```powershell
+# Writes hi to the output stream
+PS C:\> Invoke-ProcessEx cmd.exe /c 'echo hi 1>&2' -RedirectStderr Output
+# Also possible to achieve the same thing through pwsh redirection
+# Note the stderr objects will be an ErrorRecord in this case
+PS C:\> Invoke-ProcessEx cmd.exe /c 'echo hi 1>&2' 2>&1
+# Writes hi as an ErrorRecord
+PS C:\> Invoke-ProcessEx cmd.exe /c 'echo hi 1>&2'
+```
+
+The first command will redirect all stderr output to the output stream in PowerShell.
+These objects are treated as strings like normal stdout.
+The second command shows how stderr is normally written as an `ErrorRecord` in the error stream.
+It may be necessary to right `-ErrorAction Continue` so that the error being written does not stop the pipeline if `$ErrorActionPreference = 'Stop'` is set.
+
+### Example 6: Ignore stderr altogether
+```powershell
+PS C:\> Invoke-ProcessEx cmd.exe /c 'echo stdout && echo stderr 1>&2' -RedirectStderr Null
+```
+
+Ignores the all data written to the `stderr` stream and just capture the `stdout` data.
+The same thing can be achieved with `Invoke-ProcessEx cmd.exe /c 'echo stdout && echo stderr 1>&2' 2>$null` but it is more efficient to use `-RedirectStderr Null` so PowerShell does not have to process it.
+
+### Example 7: Capture the raw output as a byte array
+```powershell
+PS C:\> Invoke-ProcessEx python '-c' 'print("café")' -OutputEncoding Bytes | Format-Hex
+
+#    Label: Byte (System.Byte) <3B8382A2>
+#
+#           Offset Bytes                                           Ascii
+#                  00 01 02 03 04 05 06 07 08 09 0A 0B 0C 0D 0E 0F
+#           ------ ----------------------------------------------- -----
+# 0000000000000000 63 61 66 E9 0D 0A                               café��
+
+# The above shows the encoding is not UTF-8 but the Windows locale encoding
+# So we can run the below to capture it properly
+PS C:\> Invoke-ProcessEx python '-c' 'print("café")' -OutputEncoding ANSI
+```
+
+Outputs the raw bytes of stdout and pipes them into `Format-Hex` to see the raw data a process will output.
+This is useful for checking for encoding problems or just capturing raw bytes written by a process that isn't valid strings.
+Adding `-Raw` will output the data as a single `byte[]` at the end rather than individual bytes.
+
+### Example 8: Run a process with a ConPTY to get the exact console output
+```powershell
+PS C:\> Invoke-ProcessEx pwsh.exe '-Command' 'Get-Item $PSHome' -UseConPTY
+```
+
+Runs the process with a Console PTY that allows the caller to act as a console server.
+This is used to capture and interact with a process as it would with a terminal.
+The output will most likely contain ANSI escape codes and other interact terminal features that is hard to parse non-interactively.
+Use `-UseConPTY` with caution as the process and the arguments given must explicitly close the process or else it will hang waiting for input that will never come.
+
+## PARAMETERS
+
+### -ApplicationName
+Used with `-CommandLine` as the full path to the executable to run.
+This is useful if the `-CommandLine` executable path contains spaces and you wish to be explicit about what to run.
+
+```yaml
+Type: String
+Parameter Sets: CommandLine
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ArgumentEscaping
+The argument escaping mode to use when building the values of `-ArgumentList` to the single command line string.
+The default `Standard` will escape the argument list according to the C style rules where whitespace is fully enclosed as a double quoted string.
+The `Raw` rule will ignore all escaping and just appeach each argument with a space.
+The `Msi` rule will quote the argument `FOO=value with space` as `FOO="value with space"`.
+
+See [ConvertTo-EscapedArgument](./ConvertTo-EscapedArgument.md) for more information.
+
+```yaml
+Type: ArgumentEscapingMode
+Parameter Sets: FilePath
+Aliases:
+Accepted values: Standard, Raw, Msi
+
+Required: False
+Position: Named
+Default value: Standard
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ArgumentList
+A list of arguments to run with the `-FilePath`.
+These arguments are automatically escaped based on the Win32 C argument escaping rules as done by `ConvertTo-EscapedArgument`.
+The `-ArgumentEscaping` parameter can be used to change the escaping method from the C style to other ones.
+If you wish to provide arguments as a literal string without escaping use the `-CommandLine` option instead of this and `-FilePath`.
+
+```yaml
+Type: String[]
+Parameter Sets: FilePath
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CommandLine
+Used instead of `-FilePath` and `-ArgumentList` to run a new process with the literal string provided.
+This string is not escaped so you need to ensure it is valid for your use case.
+You can optionally specify `-ApplicationName` with this parameter to be more explicit about what executable to run.
+
+```yaml
+Type: String
+Parameter Sets: CommandLine
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConPTYHeight
+The ConPTY height to use when `-UseConPTY` is set.
+Defaults to `$host.UI.RawUI.BufferSize.Height` or `80` if no host is present.
+
+```yaml
+Type: Int16
+Parameter Sets: (All)
+Aliases: ConPTYY
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ConPTYWidth
+The ConPTY width to use when `-UseConPTY` is set.
+Defaults to `$host.UI.RawUI.BufferSize.Width` or `80` if no host is present.
+
+```yaml
+Type: Int16
+Parameter Sets: (All)
+Aliases: ConPTYX
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -DisableInheritance
+Explicitly disable all the handles in the current process from being inherited with the new process.
+This cannot be used if `-StartupInfo` has an explicit StandardInput/Output/Error or InheritedHandles list.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Environment
+A dictionary containing explicit environment variables to use for the new process.
+These env vars will be used instead of the existing process environment variables if defined.
+Use `Get-TokenEnvironment` to generate a new environment block that can be modified as needed for the new process.
+Cannot be used with `-UseNewEnvironment`.
+
+```yaml
+Type: IDictionary
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePath
+The executable to start.
+Use with `-ArgumentList` to supply a list of argument to this executable.
+
+```yaml
+Type: String
+Parameter Sets: FilePath
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputEncoding
+Sets the encoding used when writing the input strings to the input of the process.
+Will default to the value of `[Console]::InputEncoding` but can be set to an explicit `Encoding` type or one of the following string values:
+
++ `ASCII` - The 7-bit ASCII encoding
++ `ANSI` - The current system locale encoding
++ `BigEndianUnicode` - UTF-16 in Big Endian form
++ `BigEndianUtf32` - UTF-32 in Big Endian form
++ `ConsoleInput` - The console input encoding - `[Console]::InputEncoding` (Default)
++ `ConsoleOutput` - The console output encoding - `[Console]::OutputEncoding`
++ `OEM` - Same as `ConsoleOutput`
++ `Unicode` - UTF-16 in Little Endian form
++ `UTF8` - UTF-8 without a BOM
++ `UTF8Bom` - UTF-8 with a BOM
++ `UTF8NoBom` - UTF-8 without a BOM
++ `UTF32` - UTF-32 in Little Endiam form
+
+Using any other string or integer value will call `[System.Text.Encoding]::GetEncoding($_)` to build the encoding object.
+
+Setting `-InputEncoding Bytes` does not work as the input must have an encoding to convert the input strings to bytes when writing.
+This parameter is ignored if `-UseConPTY` is specified as that always outputs as UTF-8.
+
+```yaml
+Type: EncodingOrByteStream
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: ConsoleInput
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+The input objects to pipe into the process' stdin.
+Any `byte` or `byte[]` array values will be passed in directly.
+Any `string` or `string[]` values will be passed in as a line and encoded with the `-InputEncoding` parameter.
+Other object types will be casted to a string and handled as above.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -OutputEncoding
+Sets the encoding used when reading the output and error stream bytes.
+Will default to the value of `[Console]::OutputEncoding` but can be set to an explicit `Encoding` type or one of the following string values:
+
++ `ASCII` - The 7-bit ASCII encoding
++ `ANSI` - The current system locale encoding
++ `BigEndianUnicode` - UTF-16 in Big Endian form
++ `BigEndianUtf32` - UTF-32 in Big Endian form
++ `Bytes` - Outputs as raw bytes and not a string
++ `ConsoleInput` - The console input encoding - `[Console]::InputEncoding`
++ `ConsoleOutput` - The console output encoding - `[Console]::OutputEncoding` (Default)
++ `OEM` - Same as `ConsoleOutput`
++ `Unicode` - UTF-16 in Little Endian form
++ `UTF8` - UTF-8 without a BOM
++ `UTF8Bom` - UTF-8 with a BOM
++ `UTF8NoBom` - UTF-8 without a BOM
++ `UTF32` - UTF-32 in Little Endiam form
+
+Using any other string or integer value will call `[System.Text.Encoding]::GetEncoding($_)` to build the encoding object.
+
+Setting `-OutputEncoding Bytes` will output the data as raw bytes rather than a string.
+Unless set to `Bytes`, this parameter is ignored if `-UseConPTY` is specified as that always outputs as UTF-8.
+
+```yaml
+Type: EncodingOrByteStream
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: ConsoleOutput
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+When set, will output as a single string rather than an array of strings representing each line.
+If `-OutputEncoding Bytes`, the output is emitted as a single `byte[]` rather than as individual bytes.
+This only applies to both the output (stdout) and error (stderr) stream .
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RedirectStderr
+Redirect the stderr data to another location.
+Defaults to `Error` which is the PowerShell error stream.
+Set to `Output` to redirect stderr to the output stream as a string based on `-OutputEncoding`.
+Set to `Console` to skip capturing stderr together and write it directly to the console.
+Set to `Null` to discard all output on stderr.
+
+This option is ignored if `-UseConPTY` is set as there is no stderr anymore.
+
+```yaml
+Type: StdioStreamTarget
+Parameter Sets: (All)
+Aliases:
+Accepted values: Error, Output, Console, Null
+
+Required: False
+Position: Named
+Default value: Error
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RedirectStdout
+Redirect the stdout data to another location.
+Defaults to `Output` which is the PowerShell output stream.
+Set to `Error` to redirect stdout to the error stream as an error record.
+Set to `Console` to skip capturing stdout together and write it directly to the console.
+Set to `Null` to discard all output on stdout.
+
+This option is ignored if `-UseConPTY` is set as there is no stdout anymore.
+
+```yaml
+Type: StdioStreamTarget
+Parameter Sets: (All)
+Aliases:
+Accepted values: Error, Output, Console, Null
+
+Required: False
+Position: Named
+Default value: Output
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartupInfo
+Specify custom startup information as returned by `New-StartupInfo`.
+It is not possible to use a custom `-StandardInput`, `-StandardOutput`, `-StandardError`, or `-ConPTY` in the startup info.
+
+If using a custom parent process, the invoked process will be spawned in a new console and will not inherit the existing one.
+Using `-RedirectStdout Console` or `-RedirectStderr Console` will not work if using a custom parent process.
+
+```yaml
+Type: StartupInfo
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Token
+Create the process to run with the access token specified.
+This access token can be retrieved through other functions like `LogonUser`, duplicating from an existing process, etc.
+Using this parameter calls `CreateProcessAsUser` instead of `CreateProcess` which requires the `SeIncreaseQuotaPrivilege` privilege.
+It also requires the `SeAssignPrimaryTokenPrivilege` privilege if the token is not a restricted version of the callers primary token.
+The `SeAssignPrimaryTokenPrivilege` privilege is not given to administrators by default so check with `whoami.exe /priv` to see if your account has this privilege.
+The `Start-ProcessWith` cmdlet requires less sensitive privileges and can be used as an alternative to this cmdlet if needed.
+
+Be aware that this process will add the Logon Session SID of this token to the station and desktop security descriptor specified by Desktop on `-StartupInfo`.
+If no startup info was specified then the current station and desktop is used.
+Running this with multiple tokens could hit the maximum allowed size in a ACL if the station/desktop descriptor is not cleaned up.
+
+```yaml
+Type: SafeHandle
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseConPTY
+Use a Console PTY instead of the standard stdin, stdout, and stderr streams.
+This replicates running a process in an actual console without any interaction and the output will reflect the data the executable will write to the console.
+The data will typically contain interactive elements like ANSI escape codes.
+The input and output encoding is always set to UTF-8 regardless of `-InputEncoding` and `-OutputEncoding` unless `-OutputEncoding Bytes` is specified.
+In that case the output will be the raw bytes from the output handle.
+When set `-RedirectStdout` and `-RedirectStderr` will do nothing.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -UseNewEnvironment
+Instead of inheriting the current process environment variables, use a brand new set of environment variables for the current user.
+Cannot be used with `-Environment`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkingDirectory
+The working directory to set for the new process, defaults to the current filesystem location of the PowerShell process if not defined.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String[]
+The strings to write to the stdin of the new process. Each string will be appended with the value of `[Environment]::NewLine`. The encoding of each string is based on the value of `-InputEncoding`.
+
+### System.Object
+If a `byte` or `byte[]`, this input object will be written as is to the stdin of the new process. All other objects will be casted to a string and written as a line to stdin.
+
+## OUTPUTS
+
+### System.String
+By default this cmdlet outputs the stdout lines as a string for each line. If `-OutputEncoding Bytes` is set, the output will instead be the bytes of stdout rather than a string. If `-Raw` is specified the output is a single string of the full stdout or a `byte[]` of the stdout if `-OutputEncoding Bytes` is set. There is no output if `-RedirectStdout` is set to `Console`, `Null`, or `Error`.
+
+## NOTES
+This cmdlet is meant to expand on the functionality of calling a specific process.
+
+## RELATED LINKS

--- a/docs/en-US/Invoke-ProcessWith.md
+++ b/docs/en-US/Invoke-ProcessWith.md
@@ -1,0 +1,478 @@
+---
+external help file: ProcessEx.dll-Help.xml
+Module Name: ProcessEx
+online version: github.com/jborean93/ProcessEx/blob/main/docs/en-US/Invoke-ProcessWith.md
+schema: 2.0.0
+---
+
+# Invoke-ProcessWith
+
+## SYNOPSIS
+Invoke a process inline and capture the output like the call operator with the ability to run as another user or token.
+
+## SYNTAX
+
+### FilePath (Default)
+```
+Invoke-ProcessWith [-Credential <PSCredential>] [-Token <SafeHandle>] [-WithProfile] [-NetCredentialsOnly]
+ [-FilePath] <String> [-ArgumentList <String[]>] [-ArgumentEscaping <ArgumentEscapingMode>]
+ [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>] [-Environment <IDictionary>] [-InputObject <Object>]
+ [-InputEncoding <EncodingOrByteStream>] [-OutputEncoding <EncodingOrByteStream>]
+ [-RedirectStdout <StdioStreamTarget>] [-RedirectStderr <StdioStreamTarget>] [-Raw]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+### CommandLine
+```
+Invoke-ProcessWith [-Credential <PSCredential>] [-Token <SafeHandle>] [-WithProfile] [-NetCredentialsOnly]
+ -CommandLine <String> [-ApplicationName <String>] [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>]
+ [-Environment <IDictionary>] [-InputObject <Object>] [-InputEncoding <EncodingOrByteStream>]
+ [-OutputEncoding <EncodingOrByteStream>] [-RedirectStdout <StdioStreamTarget>]
+ [-RedirectStderr <StdioStreamTarget>] [-Raw] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+```
+
+## DESCRIPTION
+Invokes a process, waits for it to finish and returns the output back to PowerShell.
+This is like the builtin call operator `& whoami` but with a few more features.
+
+Some features it offers over the call operator are:
+
++ It can capture the raw bytes of the stdout/stderr streams
++ You can control the encoding used to pipe strings into and decode out of the process through a parameter rather than a global value
++ You can capture the raw bytes of the process rather than decode it to a string
++ The command can either be run from a single command line string or escaped through an array of arguments
++ You can run it as another user through the `-Token` or `-Credential` parameter
+
+Some things that this cmdlet cannot do or is not designed for
+
++ Starting an interactive process - the output can be set to a console but it is not the default
++ Dealing with env var changes between `pwsh.exe` and `powershell.exe`, use an explicit `-Environment` block to handle this better
++ Using the PowerShell minishell `powershell { ... }` does not work
+
+The cmdlet is also exposed through the `procwith` alias for easier interactive use.
+
+Like the normal call operator, when a process is complete, the `$LASTEXITCODE` variable will be set to the exit code of the process.
+
+By default the cmdlet is set to capture stdout lines in the output stream and stderr lines in the error stream.
+If `$ErrorActionPreference = 'Stop'` or `-ErrorAction Stop` is set on the cmdlet, any stderr lines will terminate the statement.
+Either explicitly set `-ErrorAction Continue` or use `-RedirectStderr` to something else to change this behaviour.
+
+Unlike [Invoke-ProcessEx](./Invoke-ProcessEx.md), this cmdlet does not require special privileges that an Administrator user typically does not have.
+While it can be run by less privileged users some of the things this API cannot do over `Invoke-ProcessEx` are:
+
++ The process is created in a new console window, it is not possible to redirect the stdout/stderr to the existing console directly
++ There is no way to run a process with a ConPTY, it must be redirected through the stdout/stderr pipes
++ Extended startup info elements like a parent process, inherited handles, job list is not supported
++ The Secondary Logon (`seclogon`) service must be running to call this API
++ The command line length is limited to a maximum of 1024 characters
++ It is not possible to disable inheritance of all inheritable handles in the current process
+
+Use [Start-ProcessWith](./Start-ProcessWith.md) to invoke a process in the background.
+
+See [Invoke-ProcessEx Examples](./Invoke-ProcessEx.md#examples) for some examples that also apply to `Invoke-ProcessWith`.
+
+## EXAMPLES
+
+### Example 1
+```powershell
+PS C:\> $cred = Get-Credential
+PS C:\> $out = Invoke-ProcessWith whoami -Credential $cred
+```
+
+Invokes `whoami` but as the user supplied by the `-Credential` value.
+
+## PARAMETERS
+
+### -ApplicationName
+Used with `-CommandLine` as the full path to the executable to run.
+This is useful if the `-CommandLine` executable path contains spaces and you wish to be explicit about what to run.
+
+```yaml
+Type: String
+Parameter Sets: CommandLine
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ArgumentEscaping
+The argument escaping mode to use when building the values of `-ArgumentList` to the single command line string.
+The default `Standard` will escape the argument list according to the C style rules where whitespace is fully enclosed as a double quoted string.
+The `Raw` rule will ignore all escaping and just appeach each argument with a space.
+The `Msi` rule will quote the argument `FOO=value with space` as `FOO="value with space"`.
+
+See [ConvertTo-EscapedArgument](./ConvertTo-EscapedArgument.md) for more information.
+
+```yaml
+Type: ArgumentEscapingMode
+Parameter Sets: FilePath
+Aliases:
+Accepted values: Standard, Raw, Msi
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ArgumentList
+A list of arguments to run with the `-FilePath`.
+These arguments are automatically escaped based on the Win32 C argument escaping rules as done by `ConvertTo-EscapedArgument`.
+The `-ArgumentEscaping` parameter can be used to change the escaping method from the C style to other ones.
+If you wish to provide arguments as a literal string without escaping use the `-CommandLine` option instead of this and `-FilePath`.
+
+```yaml
+Type: String[]
+Parameter Sets: FilePath
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -CommandLine
+Used instead of `-FilePath` and `-ArgumentList` to run a new process with the literal string provided.
+This string is not escaped so you need to ensure it is valid for your use case.
+You can optionally specify `-ApplicationName` with this parameter to be more explicit about what executable to run.
+
+```yaml
+Type: String
+Parameter Sets: CommandLine
+Aliases:
+
+Required: True
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Credential
+The user credentials to start the new process with.
+This will use the `CreateProcessWithLogon` API which logs on the user as an interactive logon or a NewCredential (network access change) logon when `-NetCredentialsOnly` is specified.
+This API can be called by non-admin accounts as it has no sensitive privilege requirements.
+Because the logon is an interactive logon, UAC restrictions will apply to the new process as it spawns as a limited user token.
+Use the `-Token` parameter after getting the linked token (requires admin rights) to bypass this UAC behaviour.
+
+When `-StartupInfo` specifies a custom station/desktop, the function will add the SID specified by the username to the station and desktop's security descriptor with `AllAccess`.
+When no startup info or Desktop is not set then the current station/desktop is used without any adjustments to their security descriptors.
+
+```yaml
+Type: PSCredential
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Environment
+A dictionary containing explicit environment variables to use for the new process.
+These env vars will be used instead of the existing process environment variables if defined.
+Use `Get-TokenEnvironment` to generate a new environment block that can be modified as needed for the new process.
+
+```yaml
+Type: IDictionary
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FilePath
+The executable to start.
+Use with `-ArgumentList` to supply a list of argument to this executable.
+
+```yaml
+Type: String
+Parameter Sets: FilePath
+Aliases:
+
+Required: True
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputEncoding
+Sets the encoding used when writing the input strings to the input of the process.
+Will default to the value of `[Console]::InputEncoding` but can be set to an explicit `Encoding` type or one of the following string values:
+
++ `ASCII` - The 7-bit ASCII encoding
++ `ANSI` - The current system locale encoding
++ `BigEndianUnicode` - UTF-16 in Big Endian form
++ `BigEndianUtf32` - UTF-32 in Big Endian form
++ `ConsoleInput` - The console input encoding - `[Console]::InputEncoding` (Default)
++ `ConsoleOutput` - The console output encoding - `[Console]::OutputEncoding`
++ `OEM` - Same as `ConsoleOutput`
++ `Unicode` - UTF-16 in Little Endian form
++ `UTF8` - UTF-8 without a BOM
++ `UTF8Bom` - UTF-8 with a BOM
++ `UTF8NoBom` - UTF-8 without a BOM
++ `UTF32` - UTF-32 in Little Endiam form
+
+Using any other string or integer value will call `[System.Text.Encoding]::GetEncoding($_)` to build the encoding object.
+
+Setting `-InputEncoding Bytes` does not work as the input must have an encoding to convert the input strings to bytes when writing.
+
+```yaml
+Type: EncodingOrByteStream
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: ConsoleInput
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -InputObject
+The input objects to pipe into the process' stdin.
+Any `byte` or `byte[]` array values will be passed in directly.
+Any `string` or `string[]` values will be passed in as a line and encoded with the `-InputEncoding` parameter.
+Other object types will be casted to a string and handled as above.
+
+```yaml
+Type: Object
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -NetCredentialsOnly
+The credential or token specified will only be used for any outbound authentication attempts, e.g. SMB file access, AD operations, etc.
+Any local actions will continue to use the callers access token.
+If using `-Credential`, the username must be in the UPN format `username@REALM.COM`.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -OutputEncoding
+Sets the encoding used when reading the output and error stream bytes.
+Will default to the value of `[Console]::OutputEncoding` but can be set to an explicit `Encoding` type or one of the following string values:
+
++ `ASCII` - The 7-bit ASCII encoding
++ `ANSI` - The current system locale encoding
++ `BigEndianUnicode` - UTF-16 in Big Endian form
++ `BigEndianUtf32` - UTF-32 in Big Endian form
++ `Bytes` - Outputs as raw bytes and not a string
++ `ConsoleInput` - The console input encoding - `[Console]::InputEncoding`
++ `ConsoleOutput` - The console output encoding - `[Console]::OutputEncoding` (Default)
++ `OEM` - Same as `ConsoleOutput`
++ `Unicode` - UTF-16 in Little Endian form
++ `UTF8` - UTF-8 without a BOM
++ `UTF8Bom` - UTF-8 with a BOM
++ `UTF8NoBom` - UTF-8 without a BOM
++ `UTF32` - UTF-32 in Little Endiam form
+
+Using any other string or integer value will call `[System.Text.Encoding]::GetEncoding($_)` to build the encoding object.
+
+Setting `-OutputEncoding Bytes` will output the data as raw bytes rather than a string.
+
+```yaml
+Type: EncodingOrByteStream
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: ConsoleOutput
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ProgressAction
+New common parameter introduced in PowerShell 7.4.
+
+```yaml
+Type: ActionPreference
+Parameter Sets: (All)
+Aliases: proga
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Raw
+When set, will output as a single string rather than an array of strings representing each line.
+If `-OutputEncoding Bytes`, the output is emitted as a single `byte[]` rather than as individual bytes.
+This only applies to both the output (stdout) and error (stderr) stream .
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RedirectStderr
+Redirect the stderr data to another location.
+Defaults to `Error` which is the PowerShell error stream.
+Set to `Output` to redirect stderr to the output stream as a string based on `-OutputEncoding`.
+Set to `Console` to skip capturing stderr together and write it directly to the console.
+Set to `Null` to discard all output on stderr.
+
+```yaml
+Type: StdioStreamTarget
+Parameter Sets: (All)
+Aliases:
+Accepted values: Error, Output, Console, Null
+
+Required: False
+Position: Named
+Default value: Error
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RedirectStdout
+Redirect the stdout data to another location.
+Defaults to `Output` which is the PowerShell output stream.
+Set to `Error` to redirect stdout to the error stream as an error record.
+Set to `Console` to skip capturing stdout together and write it directly to the console.
+Set to `Null` to discard all output on stdout.
+
+```yaml
+Type: StdioStreamTarget
+Parameter Sets: (All)
+Aliases:
+Accepted values: Error, Output, Console, Null
+
+Required: False
+Position: Named
+Default value: Output
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -StartupInfo
+Specify custom startup information as returned by `New-StartupInfo`.
+It is not possible to use a custom `-StandardInput`, `-StandardOutput`, `-StandardError`, or `-ConPTY` in the startup info.
+The `Invoke-ProcessWith` cmdlet also explicitly sets `ShowWindow` to `Hide` when running ignoring any existing value set there.
+
+Certain startup info elemenents cannot be used by the `*With` process style cmdlets like `-ParentProcess`, `-InheritedHandle`, `-JobList`.
+
+```yaml
+Type: StartupInfo
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Token
+Creates the process to run with the specified access token instead of explicit credentials.
+This access token can be retrieved by using other APIs like `LogonUser` or by duplicating an existing access token of a running process.
+The token should have been opened with `Query`, `Duplicate`, and `AssignPrimary` rights.
+The `AdjustSessionId` and `AdjutDefault` access may also be required if using a token from another session, e.g. a `SYSTEM` token.
+This will use the `CreateProcessWithToken` API which requires the `SeImpersonatePrivilege` privileges usually held by administrators on the host.
+
+Be aware that this process will add the Logon Session SID of this token to the station and desktop security descriptor specified by Desktop on `-StartupInfo`.
+If no startup info was specified then the current station and desktop is used.
+Running this with multiple tokens could hit the maximum allowed size in a ACL if the station/desktop descriptor is not cleaned up.
+
+```yaml
+Type: SafeHandle
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WithProfile
+Loads the user profile specified by the `-Credential` or `-Token`, including the `HKCU` registry hive.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -WorkingDirectory
+The working directory to set for the new process, defaults to the current filesystem location of the PowerShell process if not defined.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable. For more information, see [about_CommonParameters](http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### System.String[]
+The strings to write to the stdin of the new process. Each string will be appended with the value of `[Environment]::NewLine`. The encoding of each string is based on the value of `-InputEncoding`.
+
+### System.Object
+If a `byte` or `byte[]`, this input object will be written as is to the stdin of the new process. All other objects will be casted to a string and written as a line to stdin.
+
+## OUTPUTS
+
+### System.String
+By default this cmdlet outputs the stdout lines as a string for each line. If `-OutputEncoding Bytes` is set, the output will instead be the bytes of stdout rather than a string. If `-Raw` is specified the output is a single string of the full stdout or a `byte[]` of the stdout if `-OutputEncoding Bytes` is set. There is no output if `-RedirectStdout` is set to `Console`, `Null`, or `Error`.
+
+## NOTES
+This cmdlet is meant to expand on the functionality of calling a specific process.
+
+## RELATED LINKS

--- a/docs/en-US/ProcessEx.md
+++ b/docs/en-US/ProcessEx.md
@@ -29,6 +29,12 @@ Get the startupinfo for the current process.
 ### [Get-TokenEnvironment](Get-TokenEnvironment.md)
 Get environment block for a user token.
 
+### [Invoke-ProcessEx](Invoke-ProcessEx.md)
+Invoke a process inline and capture the output like the call operator.
+
+### [Invoke-ProcessWith](Invoke-ProcessWith.md)
+Invoke a process inline and capture the output like the call operator with the ability to run as another user or token.
+
 ### [New-ConPTY](New-ConPTY.md)
 Create a new pseudo console object.
 

--- a/docs/en-US/Start-ProcessEx.md
+++ b/docs/en-US/Start-ProcessEx.md
@@ -33,6 +33,8 @@ Start-ProcessEx -CommandLine <String> [-ApplicationName <String>] [-WorkingDirec
 ## DESCRIPTION
 Like `Start-Process` but exposes a few more low level options and focuses specifically on the Win32 API `CreateProcess` or `CreateProcessAsUser` when `-Token` is specified.
 
+Use [Invoke-ProcessEx](./Invoke-ProcessEx.md) to run a process and capture the output inline.
+
 ## EXAMPLES
 
 ### Example 1: Start a new console process

--- a/module/ProcessEx.psd1
+++ b/module/ProcessEx.psd1
@@ -82,6 +82,8 @@
         'Get-ProcessEx'
         'Get-StartupInfo'
         'Get-TokenEnvironment'
+        'Invoke-ProcessEx'
+        'Invoke-ProcessWith'
         'New-ConPTY'
         'New-StartupInfo'
         'Resize-ConPTY'
@@ -93,7 +95,10 @@
     VariablesToExport = @()
 
     # Aliases to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no aliases to export.
-    AliasesToExport = @()
+    AliasesToExport = @(
+        'procex'
+        'procwith'
+    )
 
     # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
     PrivateData = @{

--- a/src/ProcessEx/Argument.cs
+++ b/src/ProcessEx/Argument.cs
@@ -1,34 +1,77 @@
 using System;
+using System.IO;
 using System.Management.Automation;
 using System.Text.RegularExpressions;
 
-namespace ProcessEx
+namespace ProcessEx;
+
+public enum ArgumentEscapingMode
 {
-    internal static class ArgumentHelper
+    Standard,
+    Raw,
+    Msi,
+}
+
+internal static class ArgumentHelper
+{
+    public static string ResolveExecutable(PSCmdlet cmdlet, string path, string workingDirectory)
     {
-        public static string ResolveExecutable(PSCmdlet cmdlet, string path)
+        if (path.StartsWith(".\\") || path.StartsWith("./") || path.StartsWith("..\\") || path.StartsWith("../"))
         {
-            return cmdlet.InvokeCommand.GetCommand(path, CommandTypes.Application).Source;
+            path = cmdlet.GetUnresolvedProviderPathFromPSPath(Path.Combine(workingDirectory, path));
         }
 
-        public static string EscapeArgument(string? argument)
+        return cmdlet.InvokeCommand.GetCommand(path, CommandTypes.Application)?.Source ?? path;
+    }
+
+    public static string EscapeArgument(string? argument)
+    {
+        if (string.IsNullOrEmpty(argument))
+            return "\"\"";
+        else if (!Regex.Match(argument, @"[\s""]", RegexOptions.None).Success)
+            return argument ?? "";
+
+        // Replace any double quotes in an argument with '\"'
+        string newArg = Regex.Replace(argument, @"""", @"\""");
+
+        // Double up on any '\' chars that preceded '\"'
+        newArg = Regex.Replace(newArg, @"(\\+)\\""", @"$1$1\""");
+
+        // Double up '\' at the end of the argument so it doesn't escape end quote.
+        newArg = Regex.Replace(newArg, @"(\\+)$", "$1$1");
+
+        // Finally wrap the entire argument in double quotes now we've escaped the double quotes within
+        return string.Format("\"{0}\"", newArg);
+    }
+
+    public static string EscapeArgument(string? argument, ArgumentEscapingMode mode) => mode switch
+    {
+        ArgumentEscapingMode.Standard => EscapeArgument(argument),
+        ArgumentEscapingMode.Raw => argument ?? "",
+        ArgumentEscapingMode.Msi => EscapeMsiArgument(argument),
+        _ => throw new ArgumentException("Unknown escaping mode specified"),
+    };
+
+    private static string EscapeMsiArgument(string? argument)
+    {
+        if (!Regex.Match(argument ?? "", @"^([a-zA-Z_][\w\.]*)=", RegexOptions.None).Success)
         {
-            if (String.IsNullOrEmpty(argument))
-                return "\"\"";
-            else if (!Regex.Match(argument, @"[\s""]", RegexOptions.None).Success)
-                return argument ?? "";
-
-            // Replace any double quotes in an argument with '\"'
-            string newArg = Regex.Replace(argument, @"""", @"\""");
-
-            // Double up on any '\' chars that preceded '\"'
-            newArg = Regex.Replace(newArg, @"(\\+)\\""", @"$1$1\""");
-
-            // Double up '\' at the end of the argument so it doesn't escape end quote.
-            newArg = Regex.Replace(newArg, @"(\\+)$", "$1$1");
-
-            // Finally wrap the entire argument in double quotes now we've escaped the double quotes within
-            return String.Format("\"{0}\"", newArg);
+            return EscapeArgument(argument);
         }
+
+        int equalsIdx = argument!.IndexOf('=');
+        string propName = argument.Substring(0, equalsIdx);
+        string propValue = argument.Substring(equalsIdx + 1);
+
+        // https://learn.microsoft.com/en-us/windows/win32/msi/command-line-options
+        // Need to quote the value and escape " with "".
+        bool quoteValue = propValue.Length == 0 || propValue.IndexOfAny([' ', '"']) != -1;
+        propValue = propValue.Replace("\"", "\"\"");
+        if (quoteValue)
+        {
+            propValue = $"\"{propValue}\"";
+        }
+
+        return $"{propName}={propValue}";
     }
 }

--- a/src/ProcessEx/Commands/ConPTY.cs
+++ b/src/ProcessEx/Commands/ConPTY.cs
@@ -54,7 +54,6 @@ namespace ProcessEx.Commands
             if (InheritCursor)
                 flags |= Native.Helpers.PseudoConsoleCreateFlags.PSEUDOCONSOLE_INHERIT_CURSOR;
 
-
             try
             {
                 WriteObject(Native.Kernel32.CreatePseudoConsole(size, InputPipe, OutputPipe, flags));

--- a/src/ProcessEx/Commands/EscapedArgument.cs
+++ b/src/ProcessEx/Commands/EscapedArgument.cs
@@ -1,33 +1,35 @@
 using System.Management.Automation;
 
-namespace ProcessEx.Commands
+namespace ProcessEx.Commands;
+
+[Cmdlet(
+    VerbsData.ConvertTo, "EscapedArgument"
+)]
+[OutputType(typeof(string))]
+public class ConvertToEscapedArgument : PSCmdlet
 {
-    [Cmdlet(
-        VerbsData.ConvertTo, "EscapedArgument"
+    [Parameter(
+        Mandatory = true,
+        Position = 0,
+        ValueFromPipeline = true,
+        ValueFromPipelineByPropertyName = true
     )]
-    [OutputType(typeof(string))]
-    public class ConvertToEscapedArgument : PSCmdlet
+    [AllowEmptyString]
+    [AllowNull]
+    public string[]? InputObject;
+
+    [Parameter]
+    public ArgumentEscapingMode ArgumentEscaping { get; set; } = ArgumentEscapingMode.Standard;
+
+    protected override void ProcessRecord()
     {
-        [Parameter(
-            Mandatory = true,
-            Position = 0,
-            ValueFromPipeline = true,
-            ValueFromPipelineByPropertyName = true
-        )]
-        [AllowEmptyString]
-        [AllowNull]
-        public string[]? InputObject;
-
-        protected override void ProcessRecord()
+        if (InputObject == null || InputObject.Length == 0)
         {
-            if (InputObject == null || InputObject.Length == 0)
-            {
-                WriteObject(ArgumentHelper.EscapeArgument(null));
-                return;
-            }
-
-            foreach (string argument in InputObject)
-                WriteObject(ArgumentHelper.EscapeArgument(argument));
+            WriteObject(ArgumentHelper.EscapeArgument(null, ArgumentEscaping));
+            return;
         }
+
+        foreach (string argument in InputObject)
+            WriteObject(ArgumentHelper.EscapeArgument(argument, ArgumentEscaping));
     }
 }

--- a/src/ProcessEx/Commands/InvokeProcess.cs
+++ b/src/ProcessEx/Commands/InvokeProcess.cs
@@ -1,0 +1,937 @@
+using Microsoft.Win32.SafeHandles;
+using ProcessEx.Native;
+using System;
+using System.Buffers;
+using System.Collections;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Pipes;
+using System.Linq;
+using System.Management.Automation;
+using System.Reflection;
+using System.Runtime.InteropServices;
+using System.Security.AccessControl;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ProcessEx.Commands;
+
+public enum StdioStreamTarget
+{
+    /// <summary>
+    /// Sends the stream to the error stream as an ErrorRecord.
+    /// This is the default for stderr.
+    /// </summary>
+    Error,
+    /// <summary>
+    /// Sends the stream to the output stream as a string or byte array.
+    /// This is the default for stdout.
+    /// </summary>
+    Output,
+    /// <summary>
+    /// Does not redirect the stream and has it write to the console.
+    /// </summary>
+    Console,
+    /// <summary>
+    /// Discards all stream output.
+    /// </summary>
+    Null,
+}
+
+public abstract class InvokeProcessBase : PSCmdlet, IDisposable
+{
+    private sealed class ProcessWaitHandle : WaitHandle
+    {
+        public ProcessWaitHandle(SafeHandle handle)
+        {
+            SafeWaitHandle = new(handle.DangerousGetHandle(), false);
+        }
+    }
+
+    private static PropertyInfo? _errorRecord_PreserveInvocationInfoOnce;
+
+    private readonly CancellationTokenSource _cancelTokenSource = new();
+    private readonly BlockingCollection<object> _outData = [];
+    private ProcessInfo? _procInfo;
+
+    private SafeFileHandle? _nullHandle;
+    internal AnonymousPipeServerStream? _inputStream;
+    internal AnonymousPipeServerStream? _outputStream;
+    internal AnonymousPipeServerStream? _errorStream;
+    internal Task? _outputTask;
+    internal Task? _errorTask;
+
+    [Parameter(
+        Mandatory = true,
+        Position = 0,
+        ParameterSetName = "FilePath"
+    )]
+    public string FilePath { get; set; } = "";
+
+    [Parameter(
+        ValueFromRemainingArguments = true,
+        ParameterSetName = "FilePath"
+    )]
+    public string[] ArgumentList { get; set; } = [];
+
+    [Parameter(ParameterSetName = "FilePath")]
+    public ArgumentEscapingMode ArgumentEscaping { get; set; } = ArgumentEscapingMode.Standard;
+
+    [Parameter(
+        Mandatory = true,
+        ParameterSetName = "CommandLine"
+    )]
+    public string CommandLine { get; set; } = "";
+
+    [Parameter(
+        ParameterSetName = "CommandLine"
+    )]
+    public string ApplicationName { get; set; } = "";
+
+    [Parameter]
+    public string WorkingDirectory { get; set; } = "";
+
+    [Parameter]
+    public StartupInfo? StartupInfo { get; set; }
+
+    [Parameter]
+    public IDictionary? Environment { get; set; }
+
+    [Parameter(ValueFromPipeline = true)]
+    public object? InputObject { get; set; }
+
+    [Parameter]
+    [EncodingOrByteStreamTransform]
+#if NET6_0_OR_GREATER
+    [EncodingOrByteStreamCompletions]
+#else
+    [ArgumentCompleter(typeof(EncodingOrByteStreamCompletionsAttribute))]
+#endif
+    public EncodingOrByteStream? InputEncoding { get; set; }
+
+    [Parameter]
+    [EncodingOrByteStreamTransform]
+#if NET6_0_OR_GREATER
+    [EncodingOrByteStreamCompletions]
+#else
+    [ArgumentCompleter(typeof(EncodingOrByteStreamCompletionsAttribute))]
+#endif
+    public EncodingOrByteStream? OutputEncoding { get; set; }
+
+    [Parameter]
+    public StdioStreamTarget RedirectStdout { get; set; } = StdioStreamTarget.Output;
+
+    [Parameter]
+    public StdioStreamTarget RedirectStderr { get; set; } = StdioStreamTarget.Error;
+
+    [Parameter]
+    public SwitchParameter Raw { get; set; }
+
+    internal bool CloseInputAfterExit { get; set; }
+
+    protected override void BeginProcessing()
+    {
+        string workingDirectory = string.IsNullOrWhiteSpace(WorkingDirectory)
+            ? SessionState.Path.CurrentFileSystemLocation.Path
+            : WorkingDirectory;
+
+        if (ParameterSetName == "FilePath")
+        {
+            ApplicationName = ArgumentHelper.ResolveExecutable(this, FilePath, workingDirectory);
+
+            List<string> commands = [ApplicationName, .. ArgumentList];
+            CommandLine = string.Join(" ", commands.Select(a => ArgumentHelper.EscapeArgument(a, ArgumentEscaping)));
+        }
+
+        if (InputEncoding?.IsByteStream == true)
+        {
+            ArgumentException ex = new(
+                "Cannot use -InputEncoding Bytes, the input must have an encoding set.");
+            ErrorRecord err = new(
+                ex,
+                "InvokeWithInputEncodingAsBytes",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+        StartupInfo startupInfo = StartupInfo?.Clone() ?? new StartupInfo();
+        if (startupInfo.ConPTY.DangerousGetHandle() != IntPtr.Zero)
+        {
+            ArgumentException ex = new("Cannot use -StartupInfo with a ConPTY handle.");
+            ErrorRecord err = new(
+                ex,
+                "InvokeWithConPTY",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+        if (startupInfo.StandardInput.DangerousGetHandle() != IntPtr.Zero ||
+            startupInfo.StandardOutput.DangerousGetHandle() != IntPtr.Zero ||
+            startupInfo.StandardError.DangerousGetHandle() != IntPtr.Zero)
+        {
+            ArgumentException ex = new(
+                "Cannot use -StartupInfo with Standard Input, Output, or Error handles.");
+            ErrorRecord err = new(
+                ex,
+                "InvokeWithStdioHandle",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+        SetupProcessIO(startupInfo);
+
+        WriteVerbose(string.Format("Starting new process with\n\t{0}", string.Join("\n\t",
+        [
+            $"ApplicationName: {ApplicationName}",
+            $"CommandLine: {CommandLine}",
+            $"WorkingDirectory: {workingDirectory}",
+        ])));
+        _procInfo = StartProcess(
+            ApplicationName,
+            CommandLine,
+            CreationFlags.None,
+            Environment,
+            workingDirectory,
+            startupInfo);
+
+        _inputStream?.DisposeLocalCopyOfClientHandle();
+        _outputStream?.DisposeLocalCopyOfClientHandle();
+        _errorStream?.DisposeLocalCopyOfClientHandle();
+    }
+
+    protected override void ProcessRecord()
+    {
+        if (_inputStream is null || InputObject is null)
+        {
+            return;
+        }
+
+        object inData = InputObject;
+        if (inData is PSObject psObj)
+        {
+            inData = psObj.BaseObject;
+        }
+
+        Encoding inputEncoding = InputEncoding?.Encoding ?? Console.InputEncoding;
+        if (inData is byte byteIn)
+        {
+            WriteInputBytes(_inputStream, [byteIn]);
+        }
+        else if (inData is byte[] byteArrayIn)
+        {
+            WriteInputBytes(_inputStream, byteArrayIn);
+        }
+        else if (inData is string stringIn)
+        {
+            WriteInputLine(_inputStream, inputEncoding, stringIn);
+        }
+        else if (inData is string[] stringArrayIn)
+        {
+            foreach (string val in stringArrayIn)
+            {
+                WriteInputLine(_inputStream, inputEncoding, val);
+            }
+        }
+        else if (inData is IList inList)
+        {
+            foreach (object val in inList)
+            {
+                if (val is byte byteValue)
+                {
+                    WriteInputBytes(_inputStream, [byteValue]);
+                }
+                else
+                {
+                    string rawString = LanguagePrimitives.ConvertTo<string>(val);
+                    WriteInputLine(_inputStream, inputEncoding, rawString);
+                }
+            }
+        }
+        else
+        {
+            string stdinString = LanguagePrimitives.ConvertTo<string>(inData);
+            WriteInputLine(_inputStream, inputEncoding, stdinString);
+        }
+
+        // See if there is any output already ready to write.
+        while (_outData.TryTake(out object? currentOutput, 0, _cancelTokenSource.Token))
+        {
+            WriteResult(currentOutput);
+        }
+    }
+
+    protected override void EndProcessing()
+    {
+        if (_procInfo is null)
+        {
+            return;
+        }
+
+        if (_inputStream is not null && !CloseInputAfterExit)
+        {
+            WriteVerbose("Closing stdin pipe");
+            _inputStream.Close();
+        }
+
+        Task<int> procWait = Task.Run(() => WaitForExitAsync(_procInfo, _cancelTokenSource.Token));
+        foreach (object data in _outData.GetConsumingEnumerable(_cancelTokenSource.Token))
+        {
+            WriteResult(data);
+        }
+
+        WriteVerbose("Waiting for process to end");
+        int rc = procWait.GetAwaiter().GetResult();
+
+        WriteVerbose($"Setting $LASTEXITCODE to {rc}");
+        SessionState.PSVariable.Set("global:LASTEXITCODE", rc);
+    }
+
+    protected override void StopProcessing()
+    {
+        if (_procInfo is not null)
+        {
+            Kernel32.TerminateProcess(_procInfo.Process, -1);
+        }
+        _cancelTokenSource.Cancel();
+    }
+
+    internal abstract ProcessInfo StartProcess(
+        string applicationName,
+        string commandLine,
+        CreationFlags creationFlags,
+        IDictionary? environment,
+        string workingDirectory,
+        StartupInfo startupInfo);
+
+    internal virtual void CloseInputStreams()
+    {
+        _inputStream?.Dispose();
+        _inputStream = null;
+    }
+
+    internal virtual void SetupProcessIO(StartupInfo startupInfo)
+    {
+        if (MyInvocation.ExpectingInput)
+        {
+            WriteVerbose("Creating stdin pipe");
+            _inputStream = new(PipeDirection.Out, HandleInheritability.Inheritable);
+            startupInfo.StandardInput = _inputStream.ClientSafePipeHandle;
+        }
+
+        startupInfo.StandardOutput = SetupStreamIo("stdout", RedirectStdout);
+        startupInfo.StandardError = SetupStreamIo("stderr", RedirectStderr);
+    }
+
+    internal SafeHandle SetupStreamIo(string name, StdioStreamTarget target) => target switch
+    {
+        StdioStreamTarget.Console => SetupConsoleStream(name),
+        StdioStreamTarget.Error => SetupErrorStreamAndReader(name),
+        StdioStreamTarget.Null => SetupNullStream(name),
+        StdioStreamTarget.Output => SetupOutputStreamAndReader(name),
+        _ => throw new NotImplementedException(),
+    };
+
+    private SafeHandle SetupConsoleStream(string name)
+    {
+        WriteVerbose($"Setting {name} to use the console.");
+        return Helpers.NULL_HANDLE_VALUE;
+    }
+
+    private SafeHandle SetupErrorStreamAndReader(string name)
+    {
+        Encoding encoding = OutputEncoding?.Encoding ?? Console.OutputEncoding;
+
+        WriteVerbose($"Setting {name} to output to the error stream with the encoding {encoding.HeaderName}.");
+        _errorStream ??= new(PipeDirection.In, HandleInheritability.Inheritable);
+        StreamReader reader = new(_errorStream, encoding, false, 16384, true);
+        _errorTask ??= Task.Run(() => ReadStringStream(reader, _outData, Raw, true, _cancelTokenSource.Token));
+        return _errorStream.ClientSafePipeHandle;
+    }
+
+    private SafeHandle SetupNullStream(string name)
+    {
+        WriteVerbose($"Setting {name} to output to null.");
+        _nullHandle ??= Kernel32.CreateFile(
+            // Special Win32 file used so we don't have to manually pump and
+            // discard the output.
+            "NUL",
+            FileSystemRights.Write,
+            FileShare.ReadWrite,
+            FileMode.Open,
+            FileAttributes.Normal,
+            Helpers.FileFlags.NONE);
+        return _nullHandle;
+    }
+
+    private SafeHandle SetupOutputStreamAndReader(string name)
+    {
+        Encoding? encoding = OutputEncoding?.IsByteStream == true
+            ? null
+            : OutputEncoding?.Encoding ?? Console.OutputEncoding;
+
+        _outputStream ??= new(PipeDirection.In, HandleInheritability.Inheritable);
+        if (encoding is null)
+        {
+            WriteVerbose($"Setting {name} to output to the output stream as bytes.");
+            _outputTask ??= Task.Run(() => ReadByteStream(_outputStream, _outData, Raw, _cancelTokenSource.Token));
+        }
+        else
+        {
+            WriteVerbose($"Setting {name} to output to the output stream with the encoding {encoding.HeaderName}.");
+            StreamReader reader = new(_outputStream, encoding, false, 16384, true);
+            _outputTask = Task.Run(() => ReadStringStream(reader, _outData, Raw, false, _cancelTokenSource.Token));
+        }
+
+        return _outputStream.ClientSafePipeHandle;
+    }
+
+    private static async Task ReadByteStream(
+        AnonymousPipeServerStream pipe,
+        BlockingCollection<object> outData,
+        bool raw,
+        CancellationToken cancellationToken)
+    {
+        int bufferSize = 16 * 1024;
+
+        if (raw)
+        {
+            using MemoryStream targetStream = new();
+            await pipe.CopyToAsync(targetStream, bufferSize, cancellationToken);
+            outData.Add(targetStream.ToArray(), cancellationToken);
+        }
+        else
+        {
+            byte[] buffer = ArrayPool<byte>.Shared.Rent(bufferSize);
+            try
+            {
+                while (true)
+                {
+#if NET6_0_OR_GREATER
+                    int read = await pipe.ReadAsync(buffer.AsMemory(0, bufferSize), cancellationToken);
+#else
+                    int read = await pipe.ReadAsync(buffer, 0, buffer.Length, cancellationToken);
+#endif
+                    if (read == 0)
+                    {
+                        break;
+                    }
+                    outData.Add(buffer.AsSpan(0, read).ToArray(), cancellationToken);
+                }
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(buffer);
+            }
+        }
+    }
+
+    private static async Task ReadStringStream(
+        StreamReader reader,
+        BlockingCollection<object> outData,
+        bool raw,
+        bool forError,
+        CancellationToken cancellationToken)
+    {
+        if (raw)
+        {
+            string value = await reader.ReadToEndAsync();
+            if (value == "")
+            {
+                return;
+            }
+
+            if (forError)
+            {
+                outData.Add(WrapStderrAsError(value), cancellationToken);
+            }
+            else
+            {
+                outData.Add(value, cancellationToken);
+            }
+        }
+        else
+        {
+#if NET6_0_OR_GREATER
+            while (true)
+            {
+                string? line = await reader.ReadLineAsync();
+                if (line is null)
+                {
+                    break;
+                }
+#else
+            while (!reader.EndOfStream)
+            {
+                // Hangs when reader is closed so we change the loop
+                // check for .NET Framework.
+                string line = await reader.ReadLineAsync() ?? "";
+#endif
+
+                if (forError)
+                {
+                    outData.Add(WrapStderrAsError(line), cancellationToken);
+                }
+                else
+                {
+                    outData.Add(line, cancellationToken);
+                }
+            }
+        }
+    }
+
+    private async Task<int> WaitForExitAsync(
+        ProcessInfo procInfo,
+        CancellationToken cancellationToken)
+    {
+        ProcessWaitHandle waitHandle = new(procInfo.Process);
+        TaskCompletionSource<int> tcs = new();
+        using CancellationTokenRegistration cancelRegistration = cancellationToken.Register(
+            () => tcs.SetCanceled());
+
+        int rc;
+        RegisteredWaitHandle taskWaitHandle = ThreadPool.RegisterWaitForSingleObject(
+            waitHandle,
+            (s, t) => tcs.SetResult(Kernel32.GetExitCodeProcess(procInfo.Process)),
+            null,
+            -1,
+            true);
+        try
+        {
+            rc = await tcs.Task;
+        }
+        finally
+        {
+            _procInfo = null;
+            taskWaitHandle.Unregister(waitHandle);
+        }
+
+        if (CloseInputAfterExit && _inputStream is not null)
+        {
+            CloseInputStreams();
+        }
+
+        // It is important we wait for the output and error readers to
+        // complete before marking the output collection as complete so it
+        // stores all the data available.
+        if (_outputTask is not null)
+        {
+            await _outputTask;
+        }
+        if (_errorTask is not null)
+        {
+            await _errorTask;
+        }
+        _outData.CompleteAdding();
+
+        return rc;
+    }
+
+    private static ErrorRecord WrapStderrAsError(string stderr)
+    {
+        _errorRecord_PreserveInvocationInfoOnce ??= typeof(ErrorRecord)
+            .GetProperty(
+                "PreserveInvocationInfoOnce",
+                BindingFlags.Instance | BindingFlags.NonPublic)
+            ?? throw new RuntimeException(
+                "Internal Error: Failed to find ErrorRecord.PreserveInvocationInfoOnce");
+
+        ErrorRecord err = new(
+            new RemoteException(stderr),
+            "NativeCommandError",
+            ErrorCategory.NotSpecified,
+            stderr);
+
+        // Needed so that WriteError does not change the FQEID and message to
+        // include the current cmdlet. We just want the error as a raw string.
+        _errorRecord_PreserveInvocationInfoOnce.SetValue(err, true);
+
+        return err;
+    }
+
+    private static void WriteInputLine(
+        AnonymousPipeServerStream pipe,
+        Encoding inputEncoding,
+        string line)
+    {
+        byte[] data = inputEncoding.GetBytes($"{line}{System.Environment.NewLine}");
+        WriteInputBytes(pipe, data);
+    }
+
+    private static void WriteInputBytes(
+        AnonymousPipeServerStream pipe,
+        byte[] data)
+    {
+        pipe.Write(data, 0, data.Length);
+    }
+
+    private void WriteResult(object data)
+    {
+        if (data is ErrorRecord err)
+        {
+            WriteError(err);
+        }
+        else
+        {
+            // If -Raw we don't want to enumerate any array results.
+            WriteObject(data, !Raw);
+        }
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _cancelTokenSource.Dispose();
+            _inputStream?.Dispose();
+            _outputStream?.Dispose();
+            _errorStream?.Dispose();
+            _nullHandle?.Dispose();
+            _procInfo?.Process?.Dispose();
+            _procInfo?.Thread?.Dispose();
+        }
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+}
+
+[Cmdlet(
+    VerbsLifecycle.Invoke, "ProcessEx",
+    DefaultParameterSetName = "FilePath"
+)]
+[Alias("procex")]
+[OutputType(typeof(string))]
+public sealed class InvokeProcessExCommand : InvokeProcessBase
+{
+    private SafeConsoleHandle? _conPtyHandle;
+
+    [Parameter]
+    public SwitchParameter DisableInheritance { get; set; }
+
+    [Parameter]
+    public SafeHandle? Token { get; set; }
+
+    [Parameter]
+    public SwitchParameter UseConPTY { get; set; }
+
+    [Parameter]
+    [Alias("ConPTYY")]
+    public short ConPTYHeight { get; set; } = -1;
+
+    [Parameter]
+    [Alias("ConPTYX")]
+    public short ConPTYWidth { get; set; } = -1;
+
+    [Parameter]
+    public SwitchParameter UseNewEnvironment { get; set; }
+
+    protected override void BeginProcessing()
+    {
+        if (DisableInheritance && StartupInfo?.InheritedHandles.Length > 0)
+        {
+            ArgumentException ex = new(
+                "Cannot -DisableInheritance with explicit inherited handles in StartupInfo.");
+            ErrorRecord err = new(
+                ex,
+                "DisableInheritedWithInheritedHandles",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+        if (Environment?.Count > 0 && UseNewEnvironment)
+        {
+            ArgumentException ex = new("Cannot use -Environment with -UseNewEnvironment.");
+            ErrorRecord err = new(
+                ex,
+                "UseNewEnvironmentWithEnvironment",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+#if NET6_0_OR_GREATER
+        int currentProcId = System.Environment.ProcessId;
+#else
+        int currentProcId = System.Diagnostics.Process.GetCurrentProcess().Id;
+#endif
+        if (
+            StartupInfo is not null &&
+            StartupInfo.ParentProcess != 0 &&
+            StartupInfo.ParentProcess != currentProcId &&
+            (
+                RedirectStdout == StdioStreamTarget.Console ||
+                RedirectStderr == StdioStreamTarget.Console
+            )
+        )
+        {
+            ArgumentException ex = new(
+                "Invoke-ProcessWith cannot redirect stdout/stderr to the console when using a custom parent process.");
+            ErrorRecord err = new(
+                ex,
+                "InvokeExConsoleRedirectionWithParentProc",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+        base.BeginProcessing();
+    }
+
+    internal override void CloseInputStreams()
+    {
+        base.CloseInputStreams();
+        _conPtyHandle?.Dispose();
+        _conPtyHandle = null;
+    }
+
+    internal override void SetupProcessIO(StartupInfo startupInfo)
+    {
+        if (UseConPTY)
+        {
+            // It is important we close the input stream for a ConPTY after the
+            // process has ended. Closing it before sends the ctrl+c signal and
+            // leaves the conhost process still running causing a hang. The
+            // downside is the caller must explicitly exit the process or else
+            // it'll continue to wait for input forever.
+            CloseInputAfterExit = true;
+
+            // ConPTY always uses UTF-8, set the encoding explicitly except if
+            // the output is requested to be bytes.
+            if (OutputEncoding?.IsByteStream != true)
+            {
+                OutputEncoding = new(new UTF8Encoding());
+            }
+            InputEncoding = new(new UTF8Encoding());
+
+            _inputStream = new(PipeDirection.Out, HandleInheritability.Inheritable);
+            SafeHandle outHandle = SetupStreamIo("ConPTY output", StdioStreamTarget.Output);
+
+            short x = ConPTYWidth == -1
+                ? (short)(Host?.UI?.RawUI?.BufferSize.Width ?? 80)
+                : ConPTYWidth;
+            short y = ConPTYHeight == -1
+                ? (short)(Host?.UI?.RawUI?.BufferSize.Height ?? 80)
+                : ConPTYHeight;
+            Helpers.COORD ptySize = new()
+            {
+                X = x,
+                Y = y,
+            };
+
+            _conPtyHandle = Kernel32.CreatePseudoConsole(
+                ptySize,
+                _inputStream.ClientSafePipeHandle,
+                outHandle,
+                Helpers.PseudoConsoleCreateFlags.NONE);
+
+            startupInfo.ConPTY = _conPtyHandle;
+
+            // Needed to ensure that the existing console handles aren't
+            // inherited when using a ConPTY.
+            // https://github.com/microsoft/terminal/issues/11276#issuecomment-923210023
+            startupInfo.Flags |= StartupInfoFlags.UseStdHandles;
+        }
+        else
+        {
+            base.SetupProcessIO(startupInfo);
+        }
+    }
+
+    internal override ProcessInfo StartProcess(
+        string applicationName,
+        string commandLine,
+        CreationFlags creationFlags,
+        IDictionary? environment,
+        string workingDirectory,
+        StartupInfo startupInfo)
+    {
+        bool shouldInherit = !DisableInheritance;
+        bool isIoRedirected = startupInfo.StandardInput.DangerousGetHandle() != IntPtr.Zero ||
+                startupInfo.StandardOutput.DangerousGetHandle() != IntPtr.Zero ||
+                startupInfo.StandardError.DangerousGetHandle() != IntPtr.Zero;
+        if (DisableInheritance && isIoRedirected)
+        {
+            // If the caller has asked to disable inheritance but we are
+            // redirecting a stream we need to still inherit handles but only
+            // out stdio streams as an explicit list.
+            startupInfo.InheritStdioHandles = true;
+            shouldInherit = true;
+        }
+
+#if NET6_0_OR_GREATER
+        int currentProcId = System.Environment.ProcessId;
+#else
+        int currentProcId = System.Diagnostics.Process.GetCurrentProcess().Id;
+#endif
+        if (
+            startupInfo.ParentProcess != 0 &&
+            startupInfo.ParentProcess != currentProcId &&
+            isIoRedirected
+        )
+        {
+            // If a custom parent process is specified we cannot inherit the
+            // existing console so create a new hidden one.
+            creationFlags |= CreationFlags.NewConsole;
+            startupInfo.ShowWindow = WindowStyle.Hide;
+            startupInfo.Flags |= StartupInfoFlags.UseShowWindow;
+        }
+
+        if (Token is null)
+        {
+            return ProcessRunner.CreateProcess(
+                applicationName,
+                commandLine,
+                null,
+                null,
+                shouldInherit,
+                creationFlags,
+                environment,
+                workingDirectory,
+                startupInfo,
+                UseNewEnvironment);
+        }
+        else
+        {
+            return ProcessRunner.CreateProcessAsUser(
+                Token,
+                applicationName,
+                commandLine,
+                null,
+                null,
+                shouldInherit,
+                creationFlags,
+                environment,
+                workingDirectory,
+                startupInfo,
+                UseNewEnvironment);
+        }
+    }
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+        {
+            _conPtyHandle?.Dispose();
+        }
+    }
+}
+
+[Cmdlet(
+    VerbsLifecycle.Invoke, "ProcessWith",
+    DefaultParameterSetName = "FilePath"
+)]
+[Alias("procwith")]
+[OutputType(typeof(string))]
+public sealed class InvokeProcessWithCommand : InvokeProcessBase
+{
+    [Parameter]
+    public PSCredential Credential { get; set; } = PSCredential.Empty;
+
+    [Parameter]
+    public SafeHandle? Token { get; set; }
+
+    [Parameter()]
+    public SwitchParameter WithProfile { get; set; }
+
+    [Parameter()]
+    public SwitchParameter NetCredentialsOnly { get; set; }
+
+    protected override void BeginProcessing()
+    {
+        if (Token is null && Credential == PSCredential.Empty)
+        {
+            Credential = Host.UI.PromptForCredential(
+                "cmdlet Invoke-ProcessWith",
+                "Supply values for the Credential parameter",
+                null,
+                null);
+        }
+        else if (Token is not null && Credential != PSCredential.Empty)
+        {
+            ParameterBindingException exc = new(
+                "Cannot set -Token and -Credential together.");
+            ErrorRecord err = new(
+                exc,
+                "CredentialAndTokenSet",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+        if (RedirectStdout == StdioStreamTarget.Console || RedirectStderr == StdioStreamTarget.Console)
+        {
+            ArgumentException ex = new("Invoke-ProcessWith cannot redirect stdout/stderr to the console.");
+            ErrorRecord err = new(
+                ex,
+                "InvokeWithConsoleRedirection",
+                ErrorCategory.InvalidArgument,
+                null);
+            ThrowTerminatingError(err);
+        }
+
+        base.BeginProcessing();
+    }
+
+    internal override ProcessInfo StartProcess(
+        string applicationName,
+        string commandLine,
+        CreationFlags creationFlags,
+        IDictionary? environment,
+        string workingDirectory,
+        StartupInfo startupInfo)
+    {
+        // The CreateProcessWith* APIs must create a new console and cannot
+        // inherit the console. We explicitly hide the console that is created.
+        startupInfo.ShowWindow = WindowStyle.Hide;
+        startupInfo.Flags |= StartupInfoFlags.UseShowWindow;
+
+        Helpers.LogonFlags logonFlags = Helpers.LogonFlags.NONE;
+        if (WithProfile)
+        {
+            logonFlags |= Helpers.LogonFlags.LOGON_WITH_PROFILE;
+        }
+
+        if (NetCredentialsOnly)
+        {
+            logonFlags |= Helpers.LogonFlags.LOGON_NETCREDENTIALS_ONLY;
+        }
+
+        if (Token is null)
+        {
+            (string username, string? domain) = CredentialHelper.SplitUserName(Credential.UserName);
+
+            return ProcessRunner.CreateProcessWithLogon(
+                username,
+                domain,
+                Credential.Password,
+                logonFlags,
+                applicationName,
+                commandLine,
+                creationFlags,
+                environment,
+                workingDirectory,
+                startupInfo);
+        }
+        else
+        {
+            return ProcessRunner.CreateProcessWithToken(
+                Token,
+                logonFlags,
+                applicationName,
+                commandLine,
+                creationFlags,
+                environment,
+                workingDirectory,
+                startupInfo);
+        }
+    }
+}

--- a/src/ProcessEx/Commands/ProcessEx.cs
+++ b/src/ProcessEx/Commands/ProcessEx.cs
@@ -7,218 +7,210 @@ using System.Linq;
 using System.Management.Automation;
 using System.Runtime.InteropServices;
 
-namespace ProcessEx.Commands
+namespace ProcessEx.Commands;
+
+[Cmdlet(
+    VerbsCommon.Get, "ProcessEx"
+)]
+[OutputType(typeof(ProcessInfo))]
+public class GetProcessEx : PSCmdlet
 {
-    [Cmdlet(
-        VerbsCommon.Get, "ProcessEx"
+    [Parameter(
+        Mandatory = true,
+        Position = 0,
+        ValueFromPipeline = true,
+        ValueFromPipelineByPropertyName = true
     )]
-    [OutputType(typeof(ProcessInfo))]
-    public class GetProcessEx : PSCmdlet
-    {
-        [Parameter(
-            Mandatory = true,
-            Position = 0,
-            ValueFromPipeline = true,
-            ValueFromPipelineByPropertyName = true
-        )]
-        [Alias("Id")]
-        [ArgumentCompleter(typeof(ProcessCompletor))]
-        public ProcessIntString[] Process { get; set; } = Array.Empty<ProcessIntString>();
+    [Alias("Id")]
+    [ArgumentCompleter(typeof(ProcessCompletor))]
+    public ProcessIntString[] Process { get; set; } = Array.Empty<ProcessIntString>();
 
-        [Parameter(
-            Position = 1
-        )]
-        public ProcessAccessRights Access { get; set; } = ProcessAccessRights.AllAccess;
-
-        [Parameter()]
-        public SwitchParameter Inherit { get; set; }
-
-        protected override void ProcessRecord()
-        {
-            SafeHandle threadHandle = Helpers.NULL_HANDLE_VALUE; // We cannot get the main TID after creation.
-
-            foreach (ProcessIntString proc in Process)
-            {
-                SafeHandle processHandle;
-                try
-                {
-                    processHandle = proc.ProcessHandle ?? Kernel32.OpenProcess(proc.ProcessId, Access, Inherit);
-                }
-                catch (NativeException e)
-                {
-                    WriteError(ErrorHelper.GenerateWin32Error(e, "Failed to open process handle", proc.ProcessId));
-                    continue;
-                }
-
-                WriteObject(new ProcessInfo(processHandle, threadHandle, proc.ProcessId, 0));
-            }
-        }
-    }
-
-    [Cmdlet(
-        VerbsLifecycle.Start, "ProcessEx",
-        DefaultParameterSetName = "FilePath"
+    [Parameter(
+        Position = 1
     )]
-    [OutputType(null, typeof(ProcessInfo))]
-    public class StartProcessEx : PSCmdlet
+    public ProcessAccessRights Access { get; set; } = ProcessAccessRights.AllAccess;
+
+    [Parameter()]
+    public SwitchParameter Inherit { get; set; }
+
+    protected override void ProcessRecord()
     {
-        [Parameter(
-            Mandatory = true,
-            Position = 0,
-            ParameterSetName = "FilePath"
-        )]
-        public string FilePath { get; set; } = "";
+        SafeHandle threadHandle = Helpers.NULL_HANDLE_VALUE; // We cannot get the main TID after creation.
 
-        [Parameter(
-            ValueFromRemainingArguments = true,
-            ParameterSetName = "FilePath"
-        )]
-        public string[] ArgumentList { get; set; } = Array.Empty<string>();
-
-        [Parameter(
-            Mandatory = true,
-            ParameterSetName = "CommandLine"
-        )]
-        public string CommandLine { get; set; } = "";
-
-        [Parameter(
-            ParameterSetName = "CommandLine"
-        )]
-        public string ApplicationName { get; set; } = "";
-
-        [Parameter()]
-        public string WorkingDirectory { get; set; } = "";
-
-        [Parameter()]
-        public StartupInfo? StartupInfo { get; set; }
-
-        [Parameter()]
-        public CreationFlags CreationFlags { get; set; } = CreationFlags.NewConsole;
-
-        [Parameter()]
-        public SecurityAttributes? ProcessAttribute { get; set; }
-
-        [Parameter()]
-        public SecurityAttributes? ThreadAttribute { get; set; }
-
-        [Parameter()]
-        public IDictionary? Environment { get; set; }
-
-        [Parameter()]
-        public SafeHandle? Token { get; set; }
-
-        [Parameter()]
-        public SwitchParameter UseNewEnvironment { get; set; }
-
-        [Parameter()]
-        public SwitchParameter DisableInheritance { get; set; }
-
-        [Parameter()]
-        public SwitchParameter Wait { get; set; }
-
-        [Parameter()]
-        public SwitchParameter PassThru { get; set; }
-
-        protected override void ProcessRecord()
+        foreach (ProcessIntString proc in Process)
         {
-            if (ParameterSetName == "FilePath")
-            {
-                try
-                {
-                    ApplicationName = ArgumentHelper.ResolveExecutable(this, FilePath);
-                }
-                catch (NullReferenceException) // No documentation on this exception.
-                {
-                    ApplicationName = FilePath;
-                }
-
-                List<string> commands = new List<string>() { ApplicationName };
-                commands.AddRange(ArgumentList);
-                CommandLine = String.Join(" ", commands.Select(a => ArgumentHelper.EscapeArgument(a)));
-            }
-
-            if (String.IsNullOrWhiteSpace(WorkingDirectory))
-                WorkingDirectory = SessionState.Path.CurrentFileSystemLocation.Path;
-
-            if (StartupInfo == null)
-                StartupInfo = new StartupInfo();
-
-            if ((StartupInfo?.ConPTY.DangerousGetHandle() != IntPtr.Zero) && CreationFlags == CreationFlags.NewConsole)
-            {
-                CreationFlags = CreationFlags.None;
-            }
-
-            // Always start suspended so the process object can be built properly. Just determine whether to continue
-            // waiting if the user desired that.
-            bool suspended = (CreationFlags & CreationFlags.Suspended) == CreationFlags.Suspended;
-            CreationFlags |= CreationFlags.Suspended;
-
-            if (Wait && suspended)
-            {
-                ArgumentException ex = new ArgumentException("Cannot use -Wait with -CreationFlags Suspended");
-                WriteError(new ErrorRecord(ex, "SuspendWithWait", ErrorCategory.InvalidArgument, null));
-                return;
-            }
-            if (Environment?.Count > 0 && UseNewEnvironment)
-            {
-                ArgumentException ex = new ArgumentException("Cannot use -UseNewEnvironment with environment vars");
-                WriteError(new ErrorRecord(ex, "UseNewEnvironmentWithEnvironment", ErrorCategory.InvalidArgument,
-                    null));
-                return;
-            }
-            if (DisableInheritance && StartupInfo?.InheritedHandles.Length > 0)
-            {
-                ArgumentException ex = new ArgumentException(
-                    "Cannot -DisableInheritance with explicit inherited handles in StartupInfo");
-                WriteError(new ErrorRecord(ex, "DisableInheritedWithInheritedHandles", ErrorCategory.InvalidArgument,
-                    null));
-                return;
-            }
-
-            WriteVerbose(String.Format("Starting new process with\n\t{0}", String.Join("\n\t", new string[]
-            {
-                $"ApplicationName: {ApplicationName}",
-                $"CommandLine: {CommandLine}",
-                $"DisableInheritance: {DisableInheritance}",
-                $"CreationFlags: {CreationFlags}",
-                $"WorkingDirectory: {WorkingDirectory}",
-            })));
-
-            ProcessInfo info;
+            SafeHandle processHandle;
             try
             {
-                if (Token != null)
-                {
-                    info = ProcessRunner.CreateProcessAsUser(Token, ApplicationName, CommandLine, ProcessAttribute,
-                        ThreadAttribute, !DisableInheritance, CreationFlags, Environment, WorkingDirectory, StartupInfo!,
-                        UseNewEnvironment);
-                }
-                else
-                {
-                    info = ProcessRunner.CreateProcess(ApplicationName, CommandLine, ProcessAttribute, ThreadAttribute,
-                        !DisableInheritance, CreationFlags, Environment, WorkingDirectory, StartupInfo!, UseNewEnvironment);
-                }
+                processHandle = proc.ProcessHandle ?? Kernel32.OpenProcess(proc.ProcessId, Access, Inherit);
             }
             catch (NativeException e)
             {
-                WriteError(ErrorHelper.GenerateWin32Error(e, "Failed to create process"));
-                return;
+                WriteError(ErrorHelper.GenerateWin32Error(e, "Failed to open process handle", proc.ProcessId));
+                continue;
             }
 
-            WriteVerbose($"Process created with PID {info.ProcessId} and TID {info.ThreadId}");
-            if (Wait)
-            {
-                WriteVerbose("Resuming process and waiting for it to complete");
-                ProcessRunner.ResumeAndWait(info);
-            }
-            else if (!suspended)
-            {
-                WriteVerbose("Resuming process");
-                ProcessRunner.ResumeThread(info.Thread);
-            }
-
-            if (PassThru)
-                WriteObject(info);
+            WriteObject(new ProcessInfo(processHandle, threadHandle, proc.ProcessId, 0));
         }
+    }
+}
+
+[Cmdlet(
+    VerbsLifecycle.Start, "ProcessEx",
+    DefaultParameterSetName = "FilePath"
+)]
+[OutputType(null, typeof(ProcessInfo))]
+public class StartProcessEx : PSCmdlet
+{
+    [Parameter(
+        Mandatory = true,
+        Position = 0,
+        ParameterSetName = "FilePath"
+    )]
+    public string FilePath { get; set; } = "";
+
+    [Parameter(
+        ValueFromRemainingArguments = true,
+        ParameterSetName = "FilePath"
+    )]
+    public string[] ArgumentList { get; set; } = Array.Empty<string>();
+
+    [Parameter(
+        Mandatory = true,
+        ParameterSetName = "CommandLine"
+    )]
+    public string CommandLine { get; set; } = "";
+
+    [Parameter(
+        ParameterSetName = "CommandLine"
+    )]
+    public string ApplicationName { get; set; } = "";
+
+    [Parameter()]
+    public string WorkingDirectory { get; set; } = "";
+
+    [Parameter()]
+    public StartupInfo? StartupInfo { get; set; }
+
+    [Parameter()]
+    public CreationFlags CreationFlags { get; set; } = CreationFlags.NewConsole;
+
+    [Parameter()]
+    public SecurityAttributes? ProcessAttribute { get; set; }
+
+    [Parameter()]
+    public SecurityAttributes? ThreadAttribute { get; set; }
+
+    [Parameter()]
+    public IDictionary? Environment { get; set; }
+
+    [Parameter()]
+    public SafeHandle? Token { get; set; }
+
+    [Parameter()]
+    public SwitchParameter UseNewEnvironment { get; set; }
+
+    [Parameter()]
+    public SwitchParameter DisableInheritance { get; set; }
+
+    [Parameter()]
+    public SwitchParameter Wait { get; set; }
+
+    [Parameter()]
+    public SwitchParameter PassThru { get; set; }
+
+    protected override void ProcessRecord()
+    {
+        string workingDirectory = string.IsNullOrWhiteSpace(WorkingDirectory)
+            ? SessionState.Path.CurrentFileSystemLocation.Path
+            : WorkingDirectory;
+
+        if (ParameterSetName == "FilePath")
+        {
+            ApplicationName = ArgumentHelper.ResolveExecutable(this, FilePath, workingDirectory);
+            List<string> commands = new List<string>() { ApplicationName };
+            commands.AddRange(ArgumentList);
+            CommandLine = String.Join(" ", commands.Select(a => ArgumentHelper.EscapeArgument(a)));
+        }
+
+        if (StartupInfo == null)
+            StartupInfo = new StartupInfo();
+
+        if ((StartupInfo?.ConPTY.DangerousGetHandle() != IntPtr.Zero) && CreationFlags == CreationFlags.NewConsole)
+        {
+            CreationFlags = CreationFlags.None;
+        }
+
+        // Always start suspended so the process object can be built properly. Just determine whether to continue
+        // waiting if the user desired that.
+        bool suspended = (CreationFlags & CreationFlags.Suspended) == CreationFlags.Suspended;
+        CreationFlags |= CreationFlags.Suspended;
+
+        if (Wait && suspended)
+        {
+            ArgumentException ex = new ArgumentException("Cannot use -Wait with -CreationFlags Suspended");
+            WriteError(new ErrorRecord(ex, "SuspendWithWait", ErrorCategory.InvalidArgument, null));
+            return;
+        }
+        if (Environment?.Count > 0 && UseNewEnvironment)
+        {
+            ArgumentException ex = new ArgumentException("Cannot use -UseNewEnvironment with environment vars");
+            WriteError(new ErrorRecord(ex, "UseNewEnvironmentWithEnvironment", ErrorCategory.InvalidArgument,
+                null));
+            return;
+        }
+        if (DisableInheritance && StartupInfo?.InheritedHandles.Length > 0)
+        {
+            ArgumentException ex = new ArgumentException(
+                "Cannot -DisableInheritance with explicit inherited handles in StartupInfo");
+            WriteError(new ErrorRecord(ex, "DisableInheritedWithInheritedHandles", ErrorCategory.InvalidArgument,
+                null));
+            return;
+        }
+
+        WriteVerbose(String.Format("Starting new process with\n\t{0}", String.Join("\n\t", new string[]
+        {
+            $"ApplicationName: {ApplicationName}",
+            $"CommandLine: {CommandLine}",
+            $"DisableInheritance: {DisableInheritance}",
+            $"CreationFlags: {CreationFlags}",
+            $"WorkingDirectory: {workingDirectory}",
+        })));
+
+        ProcessInfo info;
+        try
+        {
+            if (Token != null)
+            {
+                info = ProcessRunner.CreateProcessAsUser(Token, ApplicationName, CommandLine, ProcessAttribute,
+                    ThreadAttribute, !DisableInheritance, CreationFlags, Environment, workingDirectory, StartupInfo!,
+                    UseNewEnvironment);
+            }
+            else
+            {
+                info = ProcessRunner.CreateProcess(ApplicationName, CommandLine, ProcessAttribute, ThreadAttribute,
+                    !DisableInheritance, CreationFlags, Environment, workingDirectory, StartupInfo!, UseNewEnvironment);
+            }
+        }
+        catch (NativeException e)
+        {
+            WriteError(ErrorHelper.GenerateWin32Error(e, "Failed to create process"));
+            return;
+        }
+
+        WriteVerbose($"Process created with PID {info.ProcessId} and TID {info.ThreadId}");
+        if (Wait)
+        {
+            WriteVerbose("Resuming process and waiting for it to complete");
+            ProcessRunner.ResumeAndWait(info);
+        }
+        else if (!suspended)
+        {
+            WriteVerbose("Resuming process");
+            ProcessRunner.ResumeThread(info.Thread);
+        }
+
+        if (PassThru)
+            WriteObject(info);
     }
 }

--- a/src/ProcessEx/Commands/StartupInfo.cs
+++ b/src/ProcessEx/Commands/StartupInfo.cs
@@ -106,6 +106,7 @@ namespace ProcessEx.Commands
         public SafeHandle[] JobList = Array.Empty<SafeHandle>();
 
         [Parameter()]
+        [ArgumentCompleter(typeof(ProcessCompletor))]
         public ProcessIntString? ParentProcess;
 
         protected override void ProcessRecord()

--- a/src/ProcessEx/CredentialHelper.cs
+++ b/src/ProcessEx/CredentialHelper.cs
@@ -1,0 +1,17 @@
+namespace ProcessEx;
+
+internal static class CredentialHelper
+{
+    public static (string, string?) SplitUserName(string username)
+    {
+        string? domain = null;
+        if (username.IndexOf('\\') != -1)
+        {
+            string[] userSplit = username.Split(['\\'], 2);
+            domain = userSplit[0];
+            username = userSplit[1];
+        }
+
+        return (username, domain);
+    }
+}

--- a/src/ProcessEx/EncodingOrByteStream.cs
+++ b/src/ProcessEx/EncodingOrByteStream.cs
@@ -1,0 +1,116 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using System.Text;
+using System.Globalization;
+
+namespace ProcessEx;
+
+public sealed class EncodingOrByteStream
+{
+    public Encoding? Encoding { get; }
+
+    public bool IsByteStream { get; }
+
+    public EncodingOrByteStream()
+    {
+        Encoding = null;
+        IsByteStream = true;
+    }
+
+    public EncodingOrByteStream(Encoding encoding)
+    {
+        Encoding = encoding;
+        IsByteStream = false;
+    }
+}
+
+public sealed class EncodingOrByteStreamTransformAttribute : ArgumentTransformationAttribute
+{
+    internal static string[] KnownEncodings = [
+        "UTF8",
+        "ConsoleInput",
+        "ConsoleOutput",
+        "ASCII",
+        "ANSI",
+        "Bytes",
+        "OEM",
+        "Unicode",
+        "UTF8Bom",
+        "UTF8NoBom"
+    ];
+
+    public override object Transform(EngineIntrinsics engineIntrinsics, object inputData)
+    {
+        if (inputData is PSObject psObj)
+        {
+            inputData = psObj.BaseObject;
+        }
+
+        if (inputData is string inputString && inputString.ToUpperInvariant() == "BYTES")
+        {
+            return new EncodingOrByteStream();
+        }
+
+        Encoding encoding = inputData switch
+        {
+            Encoding e => e,
+            string s => GetEncodingFromString(s.ToUpperInvariant()),
+            int i => Encoding.GetEncoding(i),
+            _ => throw new ArgumentTransformationMetadataException($"Could not convert input '{inputData}' to a valid Encoding object."),
+        };
+        return new EncodingOrByteStream(encoding);
+    }
+
+    private static Encoding GetEncodingFromString(string encoding) => encoding switch
+    {
+        "ASCII" => new ASCIIEncoding(),
+        "ANSI" => Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.ANSICodePage),
+        "BIGENDIANUNICODE" => new UnicodeEncoding(true, true),
+        "BIGENDIANUTF32" => new UTF32Encoding(true, true),
+        "CONSOLEINPUT" => Console.InputEncoding,
+        "CONSOLEOUTPUT" => Console.OutputEncoding,
+        "OEM" => Console.OutputEncoding,
+        "UNICODE" => new UnicodeEncoding(),
+        "UTF8" => new UTF8Encoding(),
+        "UTF8BOM" => new UTF8Encoding(true),
+        "UTF8NOBOM" => new UTF8Encoding(),
+        "UTF32" => new UTF32Encoding(),
+        _ => Encoding.GetEncoding(encoding),
+    };
+}
+
+#if NET6_0_OR_GREATER
+public class EncodingOrByteStreamCompletionsAttribute : ArgumentCompletionsAttribute
+{
+    public EncodingOrByteStreamCompletionsAttribute() : base(EncodingOrByteStreamTransformAttribute.KnownEncodings)
+    { }
+}
+#else
+public class EncodingOrByteStreamCompletionsAttribute : IArgumentCompleter {
+    public IEnumerable<CompletionResult> CompleteArgument(
+        string commandName,
+        string parameterName,
+        string wordToComplete,
+        CommandAst commandAst,
+        IDictionary fakeBoundParameters
+    )
+    {
+        if (string.IsNullOrWhiteSpace(wordToComplete))
+        {
+            wordToComplete = "";
+        }
+
+        WildcardPattern pattern = new($"{wordToComplete}*");
+        foreach (string encoding in EncodingOrByteStreamTransformAttribute.KnownEncodings)
+        {
+            if (pattern.IsMatch(encoding))
+            {
+                yield return new CompletionResult(encoding);
+            }
+        }
+    }
+}
+#endif

--- a/src/ProcessEx/ProcessEx.csproj
+++ b/src/ProcessEx/ProcessEx.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
-    <LangVersion>10.0</LangVersion>
+    <LangVersion>12.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>
   </PropertyGroup>
@@ -23,6 +23,8 @@
 
   <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="PowerShellStandard.Library" Version="5.1.0" PrivateAssets="all" />
+    <PackageReference Include="System.Memory" Version="4.5.5" />
+    <PackageReference Include="System.Threading.Tasks.Extensions" Version="4.5.4" />
   </ItemGroup>
 
   <ItemGroup Condition=" '$(TargetFramework)' != 'net472' ">

--- a/tests/EscapedArgument.Tests.ps1
+++ b/tests/EscapedArgument.Tests.ps1
@@ -26,4 +26,34 @@ Describe "ConvertTo-EscapedArgument" {
         $actual = ($ArgumentList | ConvertTo-EscapedArgument) -join ' '
         $actual | Should -Be $Expected
     }
+
+    It "Escapes <Argument> argument correctly using MSI" -TestCases @(
+        @{ Argument = 'FOO'; Expected = 'FOO' }
+        @{ Argument = 'A=value'; Expected = 'A=value' }
+        @{ Argument = 'B='; Expected = 'B=""' }
+        @{ Argument = 'C=""'; Expected = 'C=""""""' }
+        @{ Argument = 'D=value with space'; Expected = 'D="value with space"' }
+        @{ Argument = 'E=value with "quotes" and spaces'; Expected = 'E="value with ""quotes"" and spaces"' }
+        @{ Argument = '1F=invalid prop wont be escaped on MSI rules'; Expected = '"1F=invalid prop wont be escaped on MSI rules"' }
+        @{ Argument = 'C:\path with space'; Expected = '"C:\path with space"' }
+        @{ Argument = 'F_.1=value with space'; Expected = 'F_.1="value with space"' }
+        @{ Argument = '_F.1=value with space'; Expected = '_F.1="value with space"' }
+    ) {
+        param($Argument, $Expected)
+
+        $actual = ConvertTo-EscapedArgument -ArgumentEscaping Msi -InputObject $Argument
+        $actual | Should -Be $Expected
+    }
+
+    It "Escaped <Argument> argument correctly using Raw" -TestCases @(
+        @{ Argument = 'A'; Expected = 'A' }
+        @{ Argument = 'A B'; Expected = 'A B' }
+        @{ Argument = '"A B"'; Expected = '"A B"' }
+        @{ Argument = 'A \"Test\" B'; Expected = 'A \"Test\" B' }
+    ) {
+        param($Argument, $Expected)
+
+        $actual = ConvertTo-EscapedArgument -ArgumentEscaping Raw -InputObject $Argument
+        $actual | Should -Be $Expected
+    }
 }

--- a/tests/HexDump.ps1
+++ b/tests/HexDump.ps1
@@ -1,0 +1,17 @@
+$buffer = [byte[]]::new(4096)
+$in = [Console]::OpenStandardInput()
+try {
+    $data = while ($true) {
+        $read = $in.Read($buffer, 0, $buffer.Length)
+        if ($read -eq 0) {
+            break
+        }
+
+        $buffer[0..($read - 1)]
+    }
+
+    ($data | ForEach-Object ToString X2) -join ''
+}
+finally {
+    $in.Dispose()
+}

--- a/tests/InvokeProcess.Tests.ps1
+++ b/tests/InvokeProcess.Tests.ps1
@@ -1,0 +1,928 @@
+BeforeAll {
+    . ([IO.Path]::Combine($PSScriptRoot, 'common.ps1'))
+}
+
+Describe "Invoke-ProcessEx" {
+    It "Invokes and captures output" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out | Should -Be stdout
+        $err.Count | Should -Be 1
+        $err[0].ToString() | Should -Be stderr
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Redirects stdout to console" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+            RedirectStdout = 'Console'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        $err[0].ToString() | Should -Be stderr
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Redirects stdout to null" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+            RedirectStdout = 'Null'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out | Should -BeNullOrEmpty
+        $err.Count | Should -Be 1
+        $err[0].ToString() | Should -Be stderr
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Redirects stdout to error" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+            RedirectStdout = 'Error'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out | Should -BeNullOrEmpty
+        $err.Count | Should -Be 2
+        $err[0].ToString() | Should -Be stdout
+        $err[1].ToString() | Should -Be stderr
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Redirects stderr to console" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+            RedirectStderr = 'Console'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out | Should -Be stdout
+        $err.Count | Should -Be 0
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Redirects stderr to null" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+            RedirectStderr = 'Null'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out | Should -Be stdout
+        $err.Count | Should -Be 0
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Redirects stderr to output" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            RedirectStderr = 'Output'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out.Count | Should -Be 2
+        $out | Should -Contain stdout
+        $out | Should -Contain stderr
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Swaps stdout and stderr" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine("stdout"); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+            RedirectStdout = 'Error'
+            RedirectStderr = 'Output'
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        $out | Should -Be stderr
+        $err.Count | Should -Be 1
+        $err[0].ToString() | Should -Be stdout
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Uses ConPTY" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '"caf$([char]0xE9)"; [Console]::Error.WriteLine("stderr"); exit 1'
+            UseConPTY = $true
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        ($out -join "`n") | Should -BeLike "*caf$([char]0xE9)*"
+        ($out -join "`n") | Should -BeLike '*stderr*'
+        $err.Count | Should -Be 0
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Outputs string with custom encoding <Encoding>" -TestCases @(
+        # By well known constants
+        @{ Encoding = 'ANSI'; EncodingObj = ([Text.Encoding]::GetEncoding([Globalization.CultureInfo]::CurrentCulture.TextInfo.ANSICodePage)) }
+        @{ Encoding = 'BigEndianUnicode'; EncodingObj = ([Text.UnicodeEncoding]::new($true, $true)) }
+        @{ Encoding = 'BigEndianUTF32'; EncodingObj = ([Text.UTF32Encoding]::new($true, $true)) }
+        @{ Encoding = 'ConsoleInput'; EncodingObj = ([Console]::InputEncoding) }
+        @{ Encoding = 'ConsoleOutput'; EncodingObj = ([Console]::OutputEncoding) }
+        @{ Encoding = 'OEM'; EncodingObj = ([Console]::OutputEncoding) }
+        @{ Encoding = 'Unicode'; EncodingObj = ([Text.Encoding]::Unicode) }
+        @{ Encoding = 'UTF8'; EncodingObj = ([Text.UTF8Encoding]::new()) }
+        @{ Encoding = 'UTF8Bom'; EncodingObj = ([Text.UTF8Encoding]::new($true)) }
+        @{ Encoding = 'UTF8NoBom'; EncodingObj = ([Text.UTF8Encoding]::new()) }
+        @{ Encoding = 'UTF32'; EncodingObj = ([Text.UTF32Encoding]::new()) }
+        # By string value
+        @{ Encoding = 'Windows-1252'; EncodingObj = ([Text.Encoding]::GetEncoding('Windows-1252')) }
+        # By int value
+        @{ Encoding = 65001; EncodingObject = ([Text.UTF8Encoding]::new()) }
+        # By Encoding object
+        @{ Encoding = ([Text.Encoding]::Unicode); EncodingObject = ([Text.Encoding]::Unicode) }
+    ) {
+        param ($Encoding, $EncodingObject)
+
+        $text = "caf$([char]0x0E9)"
+
+        $cmd = "`$enc = [Text.Encoding]::GetEncoding($($EncodingObject.CodePage)); `$data = `$enc.GetBytes(`"$text``n`"); for (`$i = 0; `$i -lt 2; `$i++) { [Console]::OpenStandardOutput().Write(`$data, 0, `$data.Length) }"
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', $cmd
+            OutputEncoding = $Encoding
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out.Count | Should -Be 2
+        $out[0] | Should -Be $text
+        $out[1] | Should -Be $text
+    }
+
+    It "Outputs string with custom PSObject wrapped string encoding" {
+        $text = "caf$([char]0x0E9)"
+
+        $enc = 'Unicode' | Write-Output
+
+        $cmd = "`$enc = [Text.Encoding]::Unicode; `$data = `$enc.GetBytes(`"$text``n`"); for (`$i = 0; `$i -lt 2; `$i++) { [Console]::OpenStandardOutput().Write(`$data, 0, `$data.Length) }"
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', $cmd
+            OutputEncoding = $enc
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out.Count | Should -Be 2
+        $out[0] | Should -Be $text
+        $out[1] | Should -Be $text
+    }
+
+    It "Outputs string with ASCII string encoding" {
+        $cmd = "`$enc = [Text.Encoding]::ASCII; `$data = `$enc.GetBytes(`"cafe`n`"); for (`$i = 0; `$i -lt 2; `$i++) { [Console]::OpenStandardOutput().Write(`$data, 0, `$data.Length) }"
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', $cmd
+            OutputEncoding = 'ASCII'
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out.Count | Should -Be 2
+        $out[0] | Should -Be cafe
+        $out[1] | Should -Be cafe
+    }
+
+    It "Outputs string with custom encoding and -Raw" {
+        $text = "caf$([char]0xE9)"
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '$data = [Text.Encoding]::Unicode.GetBytes("caf$([char]0xE9)`n"); for ($i = 0; $i -lt 2; $i++) { [Console]::OpenStandardOutput().Write($data, 0, $data.Length) }'
+            OutputEncoding = 'Unicode'
+            Raw = $true
+        }
+        try {
+            $out = Invoke-ProcessEx @procParams
+        }
+        catch {
+            Get-Error | Out-Host
+            throw
+        }
+
+        $out.Count | Should -Be 1
+        $out | Should -Be "$text`n$text`n"
+    }
+
+    It "Outputs as bytes" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '$data = [byte[]]@(0, 1, 2, 3); [Console]::OpenStandardOutput().Write($data, 0, 4)'
+            OutputEncoding = 'Bytes'
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out.Count | Should -Be 4
+        $out[0] | Should -BeOfType ([byte])
+        $out[0] | Should -Be 0
+        $out[1] | Should -BeOfType ([byte])
+        $out[1] | Should -Be 1
+        $out[2] | Should -BeOfType ([byte])
+        $out[2] | Should -Be 2
+        $out[3] | Should -BeOfType ([byte])
+        $out[3] | Should -Be 3
+    }
+
+    It "Outputs as bytes and -Raw" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '$data = [byte[]]@(0, 1, 2, 3); [Console]::OpenStandardOutput().Write($data, 0, 4)'
+            OutputEncoding = 'Bytes'
+            Raw = $true
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out.Count | Should -Be 4
+        , $out | Should -BeOfType ([byte[]])
+        $out[0] | Should -Be 0
+        $out[1] | Should -Be 1
+        $out[2] | Should -Be 2
+        $out[3] | Should -Be 3
+    }
+
+    It "Outputs ConPTY as bytes" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '"hi"'
+            OutputEncoding = 'Bytes'
+            UseConPTY = $true
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out | ForEach-Object {
+            $_ | Should -BeOfType ([byte])
+        }
+        $outString = [System.Text.Encoding]::UTF8.GetString($out)
+        $outString | Should -BeLike '*hi*'
+    }
+
+    It "Writes large amounts of data" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '"a" * 1MB'
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out | Should -Be ("a" * 1MB)
+    }
+
+    It "Writes input as a string" {
+        $inputEncoding = [Console]::InputEncoding
+        $expected = -join @(
+            "$(-join ($inputEncoding.GetBytes('c') | ForEach-Object ToString X2))0D0A"
+            "$(-join ($inputEncoding.GetBytes("$([char]0xE9)") | ForEach-Object ToString X2))0D0A"
+        )
+
+        $out = 'c', "$([char]0xE9)" | procex powershell.exe '-File' "$PSScriptRoot\HexDump.ps1"
+        $out | Should -Be $expected
+    }
+
+    It "Writes input as a string array" {
+        $inputEncoding = [Console]::InputEncoding
+        $expected = -join @(
+            "$(-join ($inputEncoding.GetBytes('c') | ForEach-Object ToString X2))0D0A"
+            "$(-join ($inputEncoding.GetBytes("$([char]0xE9)") | ForEach-Object ToString X2))0D0A"
+        )
+
+        $out = @(, [string[]]@('c', "$([char]0xE9)")) | procex powershell.exe '-File' "$PSScriptRoot\HexDump.ps1"
+        $out | Should -Be $expected
+    }
+
+    It "Writes input with custom encoding" {
+        $out = 'c', "$([char]0xE9)" | procex powershell.exe '-File' "$PSScriptRoot\HexDump.ps1" -InputEncoding UTF8
+        $out | Should -Be "630D0AC3A90D0A"
+    }
+
+    It "Writes input as a byte" {
+        $out = [byte[]]@(0, 1) | procex powershell.exe '-File' "$PSScriptRoot\HexDump.ps1"
+        $out | Should -Be "0001"
+    }
+
+    It "Writes input as a byte array" {
+        $out = @(, [byte[]]@(0, 1)) | procex powershell.exe '-File' "$PSScriptRoot\HexDump.ps1"
+        $out | Should -Be "0001"
+    }
+
+    It "Writes input as other type" {
+        $out = 1, @(2, [byte]3) | procex powershell.exe '-File' "$PSScriptRoot\HexDump.ps1"
+        $out | Should -Be "310D0A320D0A03"
+    }
+
+    It "Writes input with ConPTY" {
+        $procParams = @{
+            FilePath = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+            UseConPTY = $true
+        }
+        $out = "'caf$([char]0xE9)'`r`nexit`r`n" | Invoke-ProcessEx @procParams
+
+        ($out -join "`n") | Should -BeLike "*caf$([char]0xE9)*"
+        $err.Count | Should -Be 0
+    }
+
+    It "Writes input with available data" {
+        Function Test-Function {
+            Start-Sleep -Seconds 5
+            'data'
+        }
+
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '"initial"; $input'
+        }
+        $out = Test-Function | Invoke-ProcessEx @procParams
+        $out.Count | Should -Be 2
+        $out[0] | Should -Be initial
+        $out[1] | Should -Be data
+    }
+
+    It "Runs with custom working directory" {
+        $out = Invoke-ProcessEx powershell.exe '-command' '$pwd.Path' -WorkingDirectory C:\Windows
+        $out | Should -Be C:\Windows
+    }
+
+    It "Runs with custom token" -Skip:(Get-ProcessPrivilege -Name SeAssignPrimaryTokenPrivilege).IsRemoved {
+        $domain = $env:COMPUTERNAME
+        $username = "ProcessEx-Test"
+        $password = "Password123!"
+        $token = $null
+
+        $userParams = @{
+            Name = $username
+            Password = (ConvertTo-SecureString -AsPlainText -Force -String $password)
+            Description = "Test user for ProcessEx with higher privileges"
+            PasswordNeverExpires = $true
+            UserMayNotChangePassword = $true
+            GroupMembership = "Administrators"
+        }
+        $user = New-LocalAccount @userParams
+        try {
+            # PowerShell runs in lockdown mode if it cannot access the temp path. The temp path will either be the
+            # callers temp path or C:\Windows\TEMP depending on the environment settings so apply this to both.
+            ([IO.Path]::GettempPath()), 'C:\Windows\TEMP' | ForEach-Object {
+                $acl = Get-Acl -LiteralPath $_
+                $acl.AddAccessRule($acl.AccessRuleFactory($user,
+                        [System.Security.AccessControl.FileSystemRights]::FullControl,
+                        $false,
+                        [System.Security.AccessControl.InheritanceFlags]"ContainerInherit, ObjectInherit",
+                        [System.Security.AccessControl.PropagationFlags]::None,
+                        [System.Security.AccessControl.AccessControlType]::Allow))
+                Set-Acl -LiteralPath $_ -AclObject $acl
+            }
+
+            $token = [ProcessExTests.Native]::LogonUser($username, $domain, $password, 2, 0)
+
+            $out = Invoke-ProcessEx whoami -Token $token
+            $out | Should -Be "$env:COMPUTERNAME\ProcessEx-Test"
+        }
+        finally {
+            if ($token) { $token.Dispose() }
+
+            ([IO.Path]::GettempPath()), 'C:\Windows\TEMP' | ForEach-Object {
+                $acl = Get-Acl -LiteralPath $_
+                $acl.PurgeAccessRules($user)
+                Set-Acl -LiteralPath $_ -AclObject $acl
+            }
+
+            Remove-LocalAccount -Account $user
+        }
+    }
+
+    It "Runs with custom ConPTY dimensions" {
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '"Height=$($host.UI.RawUI.BufferSize.Height)"; "Width=$($host.UI.RawUI.BufferSize.Width)"'
+            UseConPTY = $true
+            ConPTYHeight = 10
+            ConPTYWidth = 20
+        }
+        $out = Invoke-ProcessEx @procParams
+
+        ($out -join "`n") | Should -BeLike "*Height=10*"
+        ($out -join "`n") | Should -BeLike "*Width=20*"
+        $err.Count | Should -Be 0
+    }
+
+    It "Inherits env var from parent" {
+        $env:ProcessExTest = 'abc'
+        try {
+            $out = Invoke-ProcessEx powershell.exe '$env:ProcessExTest'
+            $out | Should -Be abc
+        }
+        finally {
+            $env:ProcessExTest = $null
+        }
+    }
+
+    It "Runs with custom environment" {
+        $envBlock = [Environment]::GetEnvironmentVariables()
+        $envBlock['ProcessExTest'] = 'foo'
+
+        $env:ProcessExTest = 'bar'
+        try {
+            $out = Invoke-ProcessEx powershell.exe '$env:ProcessExTest' -Environment $envBlock
+            $out | Should -Be foo
+        }
+        finally {
+            $env:ProcessExTest = $null
+        }
+    }
+
+    It "Runs with new environment" {
+        $env:ProcessExTest = 'abc'
+        try {
+            $out = Invoke-ProcessEx powershell.exe '$env:ProcessExTest' -UseNewEnvironment
+            $out | Should -BeNullOrEmpty
+        }
+        finally {
+            $env:ProcessExTest = $null
+        }
+    }
+
+    It "Tests handle inheritance" {
+        $pipe = [System.IO.Pipes.AnonymousPipeServerStream]::new('In', 'Inheritable')
+        try {
+            $procParams = @{
+                FilePath = 'powershell.exe'
+                ArgumentList = '-Command', "`$pipe = [System.IO.Pipes.AnonymousPipeClientStream]::new('Out', '$($pipe.GetClientHandleAsString())'); `$pipe.WriteByte(1); `$pipe.Dispose()"
+                ErrorAction = 'Stop'
+            }
+
+            Invoke-ProcessEx @procParams
+            $pipe.DisposeLocalCopyOfClientHandle()
+
+            $pipe.ReadByte() | Should -Be 1
+        }
+        finally {
+            $pipe.Dispose()
+        }
+    }
+
+    It "Disables inheritance with redirected output" {
+        $pipe = [System.IO.Pipes.AnonymousPipeServerStream]::new('In', 'Inheritable')
+        try {
+            $procParams = @{
+                FilePath = 'powershell.exe'
+                ArgumentList = '-Command', "'test'; [System.IO.Pipes.AnonymousPipeClientStream]::new('Out', '$($pipe.GetClientHandleAsString())') | ForEach-Object Dispose"
+                DisableInheritance = $true
+                ErrorAction = 'SilentlyContinue'
+                ErrorVariable = 'err'
+                Raw = $true
+            }
+
+            $out = Invoke-ProcessEx @procParams
+            $pipe.DisposeLocalCopyOfClientHandle()
+
+            $out | Should -Be "test`r`n"
+            $err.Count | Should -Be 1
+            $err[0].ToString() | Should -BeLike "*Invalid pipe handle*"
+        }
+        finally {
+            $pipe.Dispose()
+        }
+    }
+
+    It "Disabled inheritance with ConPTY" {
+        $pipe = [System.IO.Pipes.AnonymousPipeServerStream]::new('In', 'Inheritable')
+        try {
+            $procParams = @{
+                FilePath = 'powershell.exe'
+                ArgumentList = '-Command', "[System.IO.Pipes.AnonymousPipeClientStream]::new('Out', '$($pipe.GetClientHandleAsString())') | ForEach-Object Dispose"
+                DisableInheritance = $true
+                UseConPTY = $true
+                Raw = $true
+            }
+
+            $out = Invoke-ProcessEx @procParams
+            $pipe.DisposeLocalCopyOfClientHandle()
+
+            $out | Should -BeLike "*Invalid pipe handle*"
+        }
+        finally {
+            $pipe.Dispose()
+        }
+    }
+
+    It "Disables inheritance with no redirected handles" {
+        $pipe = [System.IO.Pipes.AnonymousPipeServerStream]::new('In', 'Inheritable')
+        $tmpFile = [System.IO.Path]::GetTempFileName()
+        try {
+            $procParams = @{
+                FilePath = 'powershell.exe'
+                ArgumentList = '-Command', "try { [System.IO.Pipes.AnonymousPipeClientStream]::new('Out', '$($pipe.GetClientHandleAsString())') | ForEach-Object Dispose } catch { Set-Content -LiteralPath '$tmpFile' -Value `$_.Exception.Message }"
+                DisableInheritance = $true
+                RedirectStdout = 'Console'
+                RedirectStderr = 'Console'
+            }
+
+            Invoke-ProcessEx @procParams
+            $pipe.DisposeLocalCopyOfClientHandle()
+
+            Test-Path -LiteralPath $tmpFile | Should -BeTrue
+            Get-Content -LiteralPath $tmpFile | Should -BeLike "*Invalid pipe handle*"
+        }
+        finally {
+            if (Test-Path -LiteralPath $tmpFile) {
+                Remove-Item -Path $tmpFile -Force
+            }
+            $pipe.Dispose()
+        }
+    }
+
+    It "Runs with command line parameter" {
+        $procParams = @{
+            CommandLine = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe -Command "[Environment]::UserName"'
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out | Should -Be ([Environment]::UserName)
+    }
+
+    It "Runs with command line and application name" {
+        $procParams = @{
+            ApplicationName = 'C:\Windows\System32\WindowsPowerShell\v1.0\powershell.exe'
+            CommandLine = 'ignored.exe -Command "[Environment]::UserName"'
+        }
+        $out = Invoke-ProcessEx @procParams
+        $out | Should -Be ([Environment]::UserName)
+    }
+
+    It "Runs an executable in current directory <Path>" -TestCases @(
+        @{ Path = '.\whoami.exe'; WorkingDirectory = 'C:\Windows\System32' }
+        @{ Path = './whoami.exe'; WorkingDirectory = 'C:\Windows\System32' }
+        @{ Path = '.\..\System32\whoami.exe'; WorkingDirectory = 'C:\Windows\System32' }
+        @{ Path = './../System32/whoami.exe'; WorkingDirectory = 'C:\Windows\System32' }
+        @{ Path = '..\whoami.exe'; WorkingDirectory = 'C:\Windows\System32\WindowsPowerShell' }
+        @{ Path = '../whoami.exe'; WorkingDirectory = 'C:\Windows\System32\WindowsPowerShell' }
+    ) {
+        param ($Path, $WorkingDirectory)
+
+        $expected = whoami.exe
+        $out = Invoke-ProcessEx -FilePath $Path -WorkingDirectory $WorkingDirectory
+
+        $out | Should -Be $expected
+    }
+
+    It "Stops a still running process with the stop request with alias <UseAlias>" -TestCases @(
+        @{ UseAlias = $false }
+        @{ UseAlias = $true }
+    ) {
+        param ($UseAlias)
+
+        $cmdletName = if ($UseAlias) {
+            'procex'
+        }
+        else {
+            'Invoke-ProcessEx'
+        }
+
+        $procParams = @{
+            FilePath = 'powershell.exe'
+            ArgumentList = '-Command', 'Start-Sleep -Seconds 60'
+        }
+
+        $projectPath = Split-Path -Path $PSScriptRoot -Parent
+        $ps = [PowerShell]::Create()
+        [void]$ps.AddCommand("Import-Module").AddParameter("Name", "$projectPath\output\ProcessEx").AddStatement()
+        $task = $ps.AddCommand($cmdletName).AddParameters($procParams).BeginInvoke()
+        Start-Sleep -Seconds 5
+
+        $start = Get-Date
+        $ps.Stop()
+        $ps.EndInvoke($task)
+        $end = (Get-Date) - $start
+        $end.TotalSeconds | Should -BeLessThan 50
+    }
+
+    It "Invokes with custom parent process" {
+        $proc = Start-Process powershell.exe -PassThru -WindowStyle Hidden
+        try {
+            $si = New-StartupInfo -ParentProcess $proc
+            $procParams = @{
+                FilePath = 'powershell.exe'
+                ArgumentList = '-command', '(Get-CimInstance -ClassName Win32_Process -Filter "ProcessId=$pid").ParentProcessId'
+                StartupInfo = $si
+            }
+
+            $out = Invoke-ProcessEx @procParams
+            $out | Should -Be $proc.Id
+        }
+        finally {
+            $proc | Stop-Process
+        }
+    }
+
+    It "Fails with invalid encoding type" {
+        $ex = { Invoke-ProcessEx whoami -OutputEncoding $true } | Should -Throw -PassThru
+        [string]$ex | Should -BeLike "*Could not convert input 'True' to a valid Encoding object*"
+    }
+
+    It "Fails if -InputEncoding is set to Bytes" {
+        $procParams = @{
+            FilePath = 'whoami'
+            InputEncoding = 'Bytes'
+        }
+        $err = { Invoke-ProcessEx @procParams } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Cannot use -InputEncoding Bytes, the input must have an encoding set."
+    }
+
+    It "Fails if ConPTY handle is set" {
+        $outputPipe = [System.IO.Pipes.AnonymousPipeServerStream]::new("In", "Inheritable")
+        $inputPipe = [System.IO.Pipes.AnonymousPipeServerStream]::new("Out", "Inheritable")
+
+        $pty = New-ConPTY -Width 60 -Height 80 -InputPipe $inputPipe.ClientSafePipeHandle -OutputPipe $outputPipe.ClientSafePipeHandle
+        try {
+            $outputPipe.DisposeLocalCopyOfClientHandle()
+            $inputPipe.DisposeLocalCopyOfClientHandle()
+
+            $si = New-StartupInfo -ConPTY $pty
+            $procParams = @{
+                FilePath = 'whoami'
+                StartupInfo = $si
+            }
+            $err = { Invoke-ProcessEx @procParams } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Be "Cannot use -StartupInfo with a ConPTY handle."
+        }
+        finally {
+            $pty.Dispose()
+            $outputPipe.Dispose()
+            $inputPipe.Dispose()
+        }
+    }
+
+    It "Fails if any stdio handle is set" {
+        $pipe = [System.IO.Pipes.AnonymousPipeServerStream]::new("In", "Inheritable")
+
+        try {
+            $pipe.DisposeLocalCopyOfClientHandle()
+
+            $si = New-StartupInfo -StandardOutput $pipe.ClientSafePipeHandle
+            $procParams = @{
+                FilePath = 'whoami'
+                StartupInfo = $si
+            }
+            $err = { Invoke-ProcessEx @procParams } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Be "Cannot use -StartupInfo with Standard Input, Output, or Error handles."
+        }
+        finally {
+            $pipe.Dispose()
+        }
+    }
+
+    It "Fails if inheritance is disabled with explicit inherited handles" {
+        $fs = [System.IO.File]::OpenRead($PSCommandPath)
+        $si = New-StartupInfo -InheritedHandle $fs.SafeFileHandle
+        $procParams = @{
+            FilePath = 'whoami'
+            StartupInfo = $si
+            DisableInheritance = $true
+        }
+        $err = { Invoke-ProcessEx @procParams } | Should -Throw -PassThru
+        $fs.Dispose()
+        $err.Exception.Message | Should -Be "Cannot -DisableInheritance with explicit inherited handles in StartupInfo."
+    }
+
+    It "Fails if -Environment and -UseNewEnvironment is set" {
+        $procParams = @{
+            FilePath = 'whoami'
+            Environment = @{foo = 'bar' }
+            UseNewEnvironment = $true
+        }
+        $err = { Invoke-ProcessEx @procParams } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Cannot use -Environment with -UseNewEnvironment."
+    }
+
+    It "Fails if using custom parent process with console redirection" {
+        $proc = Start-Process powershell.exe -PassThru -WindowStyle Hidden
+        try {
+            $si = New-StartupInfo -ParentProcess $proc
+            $procParams = @{
+                FilePath = 'powershell.exe'
+                StartupInfo = $si
+                RedirectStdout = 'Console'
+            }
+
+            $err = { Invoke-ProcessEx @procParams } | Should -Throw -PassThru
+            $err.Exception.Message | Should -Be "Invoke-ProcessWith cannot redirect stdout/stderr to the console when using a custom parent process."
+        }
+        finally {
+            $proc | Stop-Process
+        }
+    }
+}
+
+Describe "Invoke-ProcessWith" {
+    BeforeAll {
+        $domain = $env:COMPUTERNAME
+        $username = "ProcessEx-Test"
+        $password = "Password123!"
+
+        $userParams = @{
+            Name = $username
+            Password = (ConvertTo-SecureString -AsPlainText -Force -String $password)
+            Description = "Test user for ProcessEx with higher privileges"
+            PasswordNeverExpires = $true
+            UserMayNotChangePassword = $true
+            GroupMembership = "Administrators"
+        }
+        $user = New-LocalAccount @userParams
+
+        # PowerShell runs in lockdown mode if it cannot access the temp path. The temp path will either be the
+        # callers temp path or C:\Windows\TEMP depending on the environment settings so apply this to both.
+        ([IO.Path]::GettempPath()), 'C:\Windows\TEMP' | ForEach-Object {
+            $acl = Get-Acl -LiteralPath $_
+            $acl.AddAccessRule($acl.AccessRuleFactory($user,
+                    [System.Security.AccessControl.FileSystemRights]::FullControl,
+                    $false,
+                    [System.Security.AccessControl.InheritanceFlags]"ContainerInherit, ObjectInherit",
+                    [System.Security.AccessControl.PropagationFlags]::None,
+                    [System.Security.AccessControl.AccessControlType]::Allow))
+            Set-Acl -LiteralPath $_ -AclObject $acl
+        }
+
+        $credential = [PSCredential]::new($userParams.Name, $userParams.Password)
+        $token = [ProcessExTests.Native]::LogonUser($username, $domain, $password, 2, 0)
+    }
+    AfterAll {
+        $token.Dispose()
+
+        ([IO.Path]::GettempPath()), 'C:\Windows\TEMP' | ForEach-Object {
+            $acl = Get-Acl -LiteralPath $_
+            $acl.PurgeAccessRules($user)
+            Set-Acl -LiteralPath $_ -AclObject $acl
+        }
+
+        Remove-LocalAccount -Account $user
+    }
+    AfterEach {
+        $profileDir = "C:\Users\$($userParams.Name)"
+        if (Test-Path -Path $profileDir) {
+            # Just in case there is something that wasn't disposed that holds a handle in the profile run the GC
+            # explicitly and wait for any pending finalizers to finish disposing the data before deleting the profile.
+            [GC]::Collect()
+            [GC]::WaitForPendingFinalizers()
+
+            [ProcessExTests.Native]::DeleteProfile($user.Value, [NullString]::Value, [NullString]::Value)
+
+            # DeleteProfile does not always delete everything, check manually
+            if (Test-Path -Path $profileDir) {
+                Remove-Item -Path $profileDir -Force -Recurse -ErrorAction SilentlyContinue
+            }
+        }
+    }
+
+    It "Invokes and captures output with token" {
+        $procParams = @{
+            Token = $token
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine(([Environment]::UserName)); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+        }
+        $out = Invoke-ProcessWith @procParams
+
+        $out | Should -Be $username
+        $err.Count | Should -Be 1
+        $err[0].ToString() | Should -Be stderr
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Invokes and captures output with credential with domain <WithDomain>" -TestCases @(
+        @{ WithDomain = $false }
+        @{ WithDomain = $true }
+    ) {
+        param ($WithDomain)
+
+        $cred = if ($WithDomain) {
+            [PSCredential]::new("$env:COMPUTERNAME\$username", $credential.Password)
+        }
+        else {
+            $credential
+        }
+        $procParams = @{
+            Credential = $cred
+            FilePath = 'powershell.exe'
+            ArgumentList = '-command', '[Console]::Out.WriteLine(([Environment]::UserName)); [Console]::Error.WriteLine("stderr"); exit 1'
+            ErrorVariable = 'err'
+            ErrorAction = 'SilentlyContinue'
+        }
+        $out = Invoke-ProcessWith @procParams
+
+        $out | Should -Be $username
+        $err.Count | Should -Be 1
+        $err[0].ToString() | Should -Be stderr
+        $LASTEXITCODE | Should -Be 1
+    }
+
+    It "Invokes and captures output with credential -NetCredentialsOnly" {
+        $cred = [PSCredential]::new('foo@bar.com', ('test' | ConvertTo-SecureString -AsPlainText -Force))
+        $procParams = @{
+            Credential = $cred
+            FilePath = 'powershell.exe'
+            ArgumentList = '-Command', '[Environment]::UserName'
+            NetCredentialsOnly = $true
+        }
+        $out = Invoke-ProcessWith @procParams
+
+        $out | Should -Be ([Environment]::UserName)
+        $LASTEXITCODE | Should -Be 0
+    }
+
+    It "Invokes with input and output" {
+        $out = 'foo', 'bar' | Invoke-ProcessWith powershell.exe '-command' '$input' -Token $token
+        $out.Count | Should -Be 2
+        $out[0] | Should -Be foo
+        $out[1] | Should -Be bar
+    }
+
+    It "Invokes with no profile" {
+        $out = Invoke-ProcessWith powershell.exe '-command' '$env:USERPROFILE' -Credential $credential
+        $out | Should -Be C:\Users\Default
+    }
+
+    It "Invokes with a profile" {
+        $out = Invoke-ProcessWith powershell.exe '-command' '$env:USERPROFILE' -Credential $credential -WithProfile
+        $out | Should -Not -Be C:\Users\Default
+    }
+
+    It "Fails if -Credential and -Token is set" {
+        $procParams = @{
+            FilePath = 'whoami'
+            Credential = $credential
+            Token = $token
+        }
+        $err = { Invoke-ProcessWith @procParams } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Cannot set -Token and -Credential together."
+    }
+
+    It "Fails if stdout is redirected to the Console" {
+        $procParams = @{
+            FilePath = 'whoami'
+            Token = $token
+            RedirectStdout = 'Console'
+        }
+        $err = { Invoke-ProcessWith @procParams } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Invoke-ProcessWith cannot redirect stdout/stderr to the console."
+    }
+
+    It "Fails if stderr is redirected to the Console" {
+        $procParams = @{
+            FilePath = 'whoami'
+            Token = $token
+            RedirectStderr = 'Console'
+        }
+        $err = { Invoke-ProcessWith @procParams } | Should -Throw -PassThru
+        $err.Exception.Message | Should -Be "Invoke-ProcessWith cannot redirect stdout/stderr to the console."
+    }
+}
+
+Describe "Encoding completions" {
+    It "Completes -OutputEncoding with no value" {
+        $actual = Complete 'Invoke-ProcessEx -OutputEncoding '
+        $actual.Count | Should -Be 10
+        $actual[0].CompletionText | Should -Be UTF8
+        $actual[1].CompletionText | Should -Be ConsoleInput
+        $actual[2].CompletionText | Should -Be ConsoleOutput
+        $actual[3].CompletionText | Should -Be ASCII
+        $actual[4].CompletionText | Should -Be ANSI
+        $actual[5].CompletionText | Should -Be Bytes
+        $actual[6].CompletionText | Should -Be OEM
+        $actual[7].CompletionText | Should -Be Unicode
+        $actual[8].CompletionText | Should -Be UTF8Bom
+        $actual[9].CompletionText | Should -Be UTF8NoBom
+    }
+
+    It "Completes -OutputEncoding with partial match" {
+        $actual = Complete 'Invoke-ProcessEx -OutputEncoding UT'
+        $actual.Count | Should -Be 3
+        $actual[0].CompletionText | Should -Be UTF8
+        $actual[1].CompletionText | Should -Be UTF8Bom
+        $actual[2].CompletionText | Should -Be UTF8NoBom
+    }
+
+    It "Completes -OutputEncoding with partial match and wildcard" {
+        $actual = Complete 'Invoke-ProcessEx -OutputEncoding UT*'
+        $actual.Count | Should -Be 3
+        $actual[0].CompletionText | Should -Be UTF8
+        $actual[1].CompletionText | Should -Be UTF8Bom
+        $actual[2].CompletionText | Should -Be UTF8NoBom
+    }
+}

--- a/tests/common.ps1
+++ b/tests/common.ps1
@@ -1,6 +1,6 @@
 #Requires -Module PSPrivilege
 
-$moduleName   = (Get-Item ([IO.Path]::Combine($PSScriptRoot, '..', 'module', '*.psd1'))).BaseName
+$moduleName = (Get-Item ([IO.Path]::Combine($PSScriptRoot, '..', 'module', '*.psd1'))).BaseName
 $manifestPath = [IO.Path]::Combine($PSScriptRoot, '..', 'output', $moduleName)
 
 if (-not (Get-Module -Name $moduleName -ErrorAction SilentlyContinue)) {
@@ -574,7 +574,7 @@ Function New-ProcessExSession {
         $location = if ($WorkingDirectory) { $WorkingDirectory } else { $pwd.Path }
         [void]$ps.AddCommand("Set-Location").AddParameter("Path", $location).AddStatement()
 
-        $testModulesPath = [IO.Path]::Combine($PSScriptRoot, '..','output', 'Modules')
+        $testModulesPath = [IO.Path]::Combine($PSScriptRoot, '..', 'output', 'Modules')
         Get-ChildItem -LiteralPath $testModulesPath -Exclude ProcessEx | ForEach-Object -Process {
             [void]$ps.AddCommand("Import-Module").AddParameter("Name", $_.FullName).AddStatement()
         }
@@ -598,7 +598,7 @@ Function New-ProcessExSession {
 }
 
 Function New-ProcessWithSession {
-    [CmdletBinding(DefaultParameterSetName="Credential")]
+    [CmdletBinding(DefaultParameterSetName = "Credential")]
     param (
         [String]
         $FilePath = (Get-Process -Id $pid).Path,
@@ -662,7 +662,7 @@ Function New-ProcessWithSession {
         $location = if ($WorkingDirectory) { $WorkingDirectory } else { $pwd.Path }
         [void]$ps.AddCommand("Set-Location").AddParameter("Path", $location).AddStatement()
 
-        $testModulesPath = [IO.Path]::Combine($PSScriptRoot, '..','output', 'Modules')
+        $testModulesPath = [IO.Path]::Combine($PSScriptRoot, '..', 'output', 'Modules')
         Get-ChildItem -LiteralPath $testModulesPath -Exclude ProcessEx | ForEach-Object -Process {
             [void]$ps.AddCommand("Import-Module").AddParameter("Name", $_.FullName).AddStatement()
         }
@@ -851,7 +851,7 @@ Function Get-ElevatedToken {
         $elevatedToken = Get-Process |
             Get-ProcessToken -Access Duplicate, Impersonate, Query -ErrorAction SilentlyContinue |
             Get-TokenPrivilege |
-            Where-Object Name -eq "SeTcbPrivilege" |
+            Where-Object Name -EQ "SeTcbPrivilege" |
             ForEach-Object -Process {
                 [ProcessExTests.Native]::ImpersonateLoggedOnUser($_.Token)
                 try {
@@ -954,12 +954,12 @@ Function New-LocalAccount {
 
     if ($GroupMembership) {
         [string[]]$sidsToAdd = @($GroupMembership | ForEach-Object {
-            [System.Security.Principal.NTAccount]::new($_).Translate([System.Security.Principal.SecurityIdentifier]).Value
-        })
+                [System.Security.Principal.NTAccount]::new($_).Translate([System.Security.Principal.SecurityIdentifier]).Value
+            })
         [string[]]$existingSids = @($userAdsi.Groups() | ForEach-Object -Process {
-            $rawSid = $_.GetType().InvokeMember("ObjectSid", "GetProperty", $null, $_, $null)
-            [System.Security.Principal.SecurityIdentifier]::new($rawSid, 0).Value
-        })
+                $rawSid = $_.GetType().InvokeMember("ObjectSid", "GetProperty", $null, $_, $null)
+                [System.Security.Principal.SecurityIdentifier]::new($rawSid, 0).Value
+            })
         $toAdd = [Linq.Enumerable]::Except($sidsToAdd, $existingSids)
 
         foreach ($group in $toAdd) {
@@ -1001,4 +1001,19 @@ Function Remove-LocalAccount {
     } | ForEach-Object {
         $adsi.Delete("User", $_.Name.Value)
     }
+}
+
+Function Global:Complete {
+    [OutputType([System.Management.Automation.CompletionResult])]
+    [CmdletBinding()]
+    param(
+        [Parameter(Mandatory, Position = 0)]
+        [string]
+        $Expression
+    )
+
+    [System.Management.Automation.CommandCompletion]::CompleteInput(
+        $Expression,
+        $Expression.Length,
+        $null).CompletionMatches
 }


### PR DESCRIPTION
Adds the Invoke-ProcessEx and Invoke-ProcessWith cmdlets which can be used to invoke a process and capture the output inside PowerShell. This is similar to invoking an executable normally in PowerShell but with the extra functionality exposed by the underlying CreateProcess* APIs in Windows.

Also adds -ArgumentEscaping which can be used to escape arguments in the MSI property format.