### PR TITLE
Add PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 * Added `Invoke-ProcessWith` and `Invoke-ProcessEx` to invoke a process and capture the output like a normal call operator
 * Added `-ArgumentEscaping` to `ConvertTo-EscapedArgument` with the ability to escape MSI style properties
+* Added `New-StartupInfo -ChildProcessPolicy` to control the child process creation policy as an extended startupinfo attribute
 
 ## v0.3.0 - 2023-02-15
 

--- a/src/ProcessEx/Commands/InvokeProcess.cs
+++ b/src/ProcessEx/Commands/InvokeProcess.cs
@@ -384,7 +384,7 @@ public abstract class InvokeProcessBase : PSCmdlet, IDisposable
         {
             WriteVerbose($"Setting {name} to output to the output stream with the encoding {encoding.HeaderName}.");
             StreamReader reader = new(_outputStream, encoding, false, 16384, true);
-            _outputTask = Task.Run(() => ReadStringStream(reader, _outData, Raw, false, _cancelTokenSource.Token));
+            _outputTask ??= Task.Run(() => ReadStringStream(reader, _outData, Raw, false, _cancelTokenSource.Token));
         }
 
         return _outputStream.ClientSafePipeHandle;
@@ -822,6 +822,7 @@ public sealed class InvokeProcessExCommand : InvokeProcessBase
         {
             _conPtyHandle?.Dispose();
         }
+        base.Dispose(disposing);
     }
 }
 

--- a/tests/InvokeProcess.Tests.ps1
+++ b/tests/InvokeProcess.Tests.ps1
@@ -630,6 +630,12 @@ Describe "Invoke-ProcessEx" {
         }
     }
 
+    It "Invokes with restricted child process policy" {
+        $si = New-StartupInfo -ChildProcessPolicy Restricted
+        $out = Invoke-ProcessEx powershell.exe '-Command' 'whoami.exe' -StartupInfo $si -RedirectStderr Output -Raw
+        $out | Should -BeLike '*The process creation has been blocked*'
+    }
+
     It "Fails with invalid encoding type" {
         $ex = { Invoke-ProcessEx whoami -OutputEncoding $true } | Should -Throw -PassThru
         [string]$ex | Should -BeLike "*Could not convert input 'True' to a valid Encoding object*"


### PR DESCRIPTION
Add support for setting PROC_THREAD_ATTRIBUTE_CHILD_PROCESS_POLICY as an extended StartupInfo attribute. This policy can be used to restrict the ability for the child process to start its own processes.