### PR TITLE
Add uint procid support and expand arg escaping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog for ProcessEx
 
+## v0.5.0 - TBD
+
+* Added support for `ProcessIntString` parameters accepting `uint` values as returned by WMI/CIM calls
+* Added `-ArgumentEscaping` to `Start-ProcessWith` and `Start-ProcessEx`
+
 ## v0.4.0 - 2024-11-07
 
 * Added `Invoke-ProcessWith` and `Invoke-ProcessEx` to invoke a process and capture the output like a normal call operator

--- a/docs/en-US/New-StartupInfo.md
+++ b/docs/en-US/New-StartupInfo.md
@@ -14,20 +14,21 @@ Create a StartupInfo object for creating a process.
 
 ### STDIO (Default)
 ```
-New-StartupInfo [-Desktop <String>] [-Title <String>] [-Position <Coordinates>] [-WindowSize <Size>]
- [-CountChars <Size>] [-FillAttribute <ConsoleFill>] [-Flags <StartupInfoFlags>] [-WindowStyle <WindowStyle>]
- [-Reserved <String>] [-Reserved2 <Byte[]>] [-StandardInput <SafeHandle>] [-StandardOutput <SafeHandle>]
- [-StandardError <SafeHandle>] [-InheritedHandle <SafeHandle[]>] [-JobList <SafeHandle[]>]
- [-ParentProcess <ProcessIntString>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
+New-StartupInfo [-ChildProcessPolicy <ChildProcessPolicy>] [-Desktop <String>] [-Title <String>]
+ [-Position <Coordinates>] [-WindowSize <Size>] [-CountChars <Size>] [-FillAttribute <ConsoleFill>]
+ [-Flags <StartupInfoFlags>] [-WindowStyle <WindowStyle>] [-Reserved <String>] [-Reserved2 <Byte[]>]
+ [-StandardInput <SafeHandle>] [-StandardOutput <SafeHandle>] [-StandardError <SafeHandle>]
+ [-InheritedHandle <SafeHandle[]>] [-JobList <SafeHandle[]>] [-ParentProcess <ProcessIntString>]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### ConPTY
 ```
-New-StartupInfo [-Desktop <String>] [-Title <String>] [-Position <Coordinates>] [-WindowSize <Size>]
- [-CountChars <Size>] [-FillAttribute <ConsoleFill>] [-Flags <StartupInfoFlags>] [-WindowStyle <WindowStyle>]
- [-Reserved <String>] [-Reserved2 <Byte[]>] [-ConPTY <SafeHandle>] [-InheritedHandle <SafeHandle[]>]
- [-JobList <SafeHandle[]>] [-ParentProcess <ProcessIntString>] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+New-StartupInfo [-ChildProcessPolicy <ChildProcessPolicy>] [-Desktop <String>] [-Title <String>]
+ [-Position <Coordinates>] [-WindowSize <Size>] [-CountChars <Size>] [-FillAttribute <ConsoleFill>]
+ [-Flags <StartupInfoFlags>] [-WindowStyle <WindowStyle>] [-Reserved <String>] [-Reserved2 <Byte[]>]
+ [-ConPTY <SafeHandle>] [-InheritedHandle <SafeHandle[]>] [-JobList <SafeHandle[]>]
+ [-ParentProcess <ProcessIntString>] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -94,6 +95,27 @@ These handles must exist in the parent process specified rather than the current
 To copy a handle in the current process to the new parent process, use `Copy-HandleToProcess`.
 
 ## PARAMETERS
+
+### -ChildProcessPolicy
+The child process policy to apply to the new process.
+This can be set to one of:
+
++ `None`
++ `Restricted` - The process cannot create child processes
++ `Override`
++ `RestrictedUnlessSecure` - The process cannot create child processes unless the child process is a secure process
+
+```yaml
+Type: ChildProcessPolicy
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
 
 ### -ConPTY
 The pseudo console handle that represents the console input and output pipelines.

--- a/docs/en-US/Start-ProcessEx.md
+++ b/docs/en-US/Start-ProcessEx.md
@@ -14,11 +14,11 @@ Start a new process.
 
 ### FilePath (Default)
 ```
-Start-ProcessEx [-FilePath] <String> [-ArgumentList <String[]>] [-WorkingDirectory <String>]
- [-StartupInfo <StartupInfo>] [-CreationFlags <CreationFlags>] [-ProcessAttribute <SecurityAttributes>]
- [-ThreadAttribute <SecurityAttributes>] [-Environment <IDictionary>] [-Token <SafeHandle>]
- [-UseNewEnvironment] [-DisableInheritance] [-Wait] [-PassThru] [-ProgressAction <ActionPreference>]
- [<CommonParameters>]
+Start-ProcessEx [-FilePath] <String> [-ArgumentList <String[]>] [-ArgumentEscaping <ArgumentEscapingMode>]
+ [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>] [-CreationFlags <CreationFlags>]
+ [-ProcessAttribute <SecurityAttributes>] [-ThreadAttribute <SecurityAttributes>] [-Environment <IDictionary>]
+ [-Token <SafeHandle>] [-UseNewEnvironment] [-DisableInheritance] [-Wait] [-PassThru]
+ [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### CommandLine
@@ -90,6 +90,26 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ArgumentEscaping
+The argument escaping mode to use when building the values of `-ArgumentList` to the single command line string.
+The default `Standard` will escape the argument list according to the C style rules where whitespace is fully enclosed as a double quoted string.
+The `Raw` rule will ignore all escaping and just appeach each argument with a space.
+The `Msi` rule will quote the argument `FOO=value with space` as `FOO="value with space"`.
+
+See [ConvertTo-EscapedArgument](./ConvertTo-EscapedArgument.md) for more information.
+
+```yaml
+Type: ArgumentEscapingMode
+Parameter Sets: FilePath
+Aliases:
+
+Required: False
+Position: Named
+Default value: Standard
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/docs/en-US/Start-ProcessWith.md
+++ b/docs/en-US/Start-ProcessWith.md
@@ -14,16 +14,16 @@ Start a new process with credentials or a token.
 
 ### FilePathCredential (Default)
 ```
-Start-ProcessWith [-FilePath] <String> [-ArgumentList <String[]>] -Credential <PSCredential>
- [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>] [-CreationFlags <CreationFlags>]
- [-Environment <IDictionary>] [-WithProfile] [-NetCredentialsOnly] [-Wait] [-PassThru]
- [-ProgressAction <ActionPreference>] [<CommonParameters>]
+Start-ProcessWith [-FilePath] <String> [-ArgumentList <String[]>] [-ArgumentEscaping <ArgumentEscapingMode>]
+ -Credential <PSCredential> [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>]
+ [-CreationFlags <CreationFlags>] [-Environment <IDictionary>] [-WithProfile] [-NetCredentialsOnly] [-Wait]
+ [-PassThru] [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
 
 ### FilePathToken
 ```
-Start-ProcessWith [-FilePath] <String> [-ArgumentList <String[]>] -Token <SafeHandle>
- [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>] [-CreationFlags <CreationFlags>]
+Start-ProcessWith [-FilePath] <String> [-ArgumentList <String[]>] [-ArgumentEscaping <ArgumentEscapingMode>]
+ -Token <SafeHandle> [-WorkingDirectory <String>] [-StartupInfo <StartupInfo>] [-CreationFlags <CreationFlags>]
  [-Environment <IDictionary>] [-WithProfile] [-NetCredentialsOnly] [-Wait] [-PassThru]
  [-ProgressAction <ActionPreference>] [<CommonParameters>]
 ```
@@ -145,6 +145,26 @@ Aliases:
 Required: False
 Position: Named
 Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -ArgumentEscaping
+The argument escaping mode to use when building the values of `-ArgumentList` to the single command line string.
+The default `Standard` will escape the argument list according to the C style rules where whitespace is fully enclosed as a double quoted string.
+The `Raw` rule will ignore all escaping and just appeach each argument with a space.
+The `Msi` rule will quote the argument `FOO=value with space` as `FOO="value with space"`.
+
+See [ConvertTo-EscapedArgument](./ConvertTo-EscapedArgument.md) for more information.
+
+```yaml
+Type: ArgumentEscapingMode
+Parameter Sets: FilePathCredential, FilePathToken
+Aliases:
+
+Required: False
+Position: Named
+Default value: Standard
 Accept pipeline input: False
 Accept wildcard characters: False
 ```

--- a/module/ProcessEx.psd1
+++ b/module/ProcessEx.psd1
@@ -19,7 +19,7 @@
     }
 
     # Version number of this module.
-    ModuleVersion = '0.4.0'
+    ModuleVersion = '0.5.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/ProcessEx/Commands/ProcessEx.cs
+++ b/src/ProcessEx/Commands/ProcessEx.cs
@@ -75,6 +75,9 @@ public class StartProcessEx : PSCmdlet
     )]
     public string[] ArgumentList { get; set; } = Array.Empty<string>();
 
+    [Parameter(ParameterSetName = "FilePath")]
+    public ArgumentEscapingMode ArgumentEscaping { get; set; } = ArgumentEscapingMode.Standard;
+
     [Parameter(
         Mandatory = true,
         ParameterSetName = "CommandLine"
@@ -128,9 +131,8 @@ public class StartProcessEx : PSCmdlet
         if (ParameterSetName == "FilePath")
         {
             ApplicationName = ArgumentHelper.ResolveExecutable(this, FilePath, workingDirectory);
-            List<string> commands = new List<string>() { ApplicationName };
-            commands.AddRange(ArgumentList);
-            CommandLine = String.Join(" ", commands.Select(a => ArgumentHelper.EscapeArgument(a)));
+            string[] commands = [ApplicationName, .. ArgumentList];
+            CommandLine = string.Join(" ", commands.Select(a => ArgumentHelper.EscapeArgument(a, ArgumentEscaping)));
         }
 
         if (StartupInfo == null)

--- a/src/ProcessEx/Commands/ProcessWith.cs
+++ b/src/ProcessEx/Commands/ProcessWith.cs
@@ -38,6 +38,10 @@ namespace ProcessEx.Commands
         )]
         public string[] ArgumentList { get; set; } = Array.Empty<string>();
 
+        [Parameter(ParameterSetName = "FilePathCredential")]
+        [Parameter(ParameterSetName = "FilePathToken")]
+        public ArgumentEscapingMode ArgumentEscaping { get; set; } = ArgumentEscapingMode.Standard;
+
         [Parameter(
             Mandatory = true,
             ParameterSetName = "CommandLineCredential"
@@ -111,9 +115,8 @@ namespace ProcessEx.Commands
             if (ParameterSetName == "FilePathCredential" || ParameterSetName == "FilePathToken")
             {
                 ApplicationName = ArgumentHelper.ResolveExecutable(this, FilePath, workingDirectory);
-                List<string> commands = new List<string>() { ApplicationName };
-                commands.AddRange(ArgumentList);
-                CommandLine = String.Join(" ", commands.Select(a => ArgumentHelper.EscapeArgument(a)));
+                string[] commands = [ApplicationName, .. ArgumentList];
+                CommandLine = string.Join(" ", commands.Select(a => ArgumentHelper.EscapeArgument(a, ArgumentEscaping)));
             }
 
             if (StartupInfo == null)

--- a/src/ProcessEx/Process.cs
+++ b/src/ProcessEx/Process.cs
@@ -23,6 +23,11 @@ namespace ProcessEx
 
         public ProcessIntString(int pid) => ProcessId = pid;
 
+        // We use unchecked to get the signed representation of the same bytes
+        // of the uint value.
+        public ProcessIntString(uint pid) : this(unchecked((int)pid))
+        { }
+
         public ProcessIntString(Process process)
         {
             ProcessId = process.Id;

--- a/tests/ProcessEx.Tests.ps1
+++ b/tests/ProcessEx.Tests.ps1
@@ -22,6 +22,14 @@ Describe "Get-ProcessEx" {
         $actual.Process -is [System.Runtime.InteropServices.SafeHandle] | Should -Be $true
     }
 
+    It "Gets process using uint32 pid" {
+        [uint32]$procId = [Convert]::ToUInt32([Convert]::ToString($pid, 2), 2)
+        $actual = Get-ProcessEx -Id $procId
+        $actual -is [ProcessEx.ProcessInfo] | Should -Be $true
+        $actual.ProcessId | Should -Be $pid
+        $actual.Process -is [System.Runtime.InteropServices.SafeHandle] | Should -Be $true
+    }
+
     It "Gets process with Process" {
         $actual = Get-ProcessEx -Id (Get-Process -Id $pid)
         $actual -is [ProcessEx.ProcessInfo] | Should -Be $true


### PR DESCRIPTION
Adds support for accepting a process id as a UInt32 value. This is useful as WMI/CIM calls typically use a UInt32 to store process id values.

Also expands the use of `-ArgumentEscaping` to the `Start-Process*` cmdlets to better match what is available in other cmdlets.