### PR TITLE
Update CI and signing process

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,9 @@ jobs:
       shell: pwsh
       run: ./build.ps1 -Configuration $env:BUILD_CONFIGURATION -Task Build
       env:
-        AZURE_KEYVAULT_NAME: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_KEYVAULT_NAME || '' }}
-        AZURE_KEYVAULT_CERT: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_KEYVAULT_CERT || '' }}
+        AZURE_TS_NAME: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_TS_NAME || '' }}
+        AZURE_TS_PROFILE: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_TS_PROFILE || '' }}
+        AZURE_TS_ENDPOINT: ${{ env.BUILD_CONFIGURATION == 'Release' && secrets.AZURE_TS_ENDPOINT || '' }}
 
     - name: Capture PowerShell Module
       uses: actions/upload-artifact@v4
@@ -65,14 +66,6 @@ jobs:
           psversion: '5.1'
           arch: x86
           os: windows-latest
-        - name: PS_7.2_x64_Windows
-          psversion: '7.2.0'
-          arch: x64
-          os: windows-latest
-        - name: PS_7.3_x64_Windows
-          psversion: '7.3.0'
-          arch: x64
-          os: windows-latest
         - name: PS_7.4_x64_Windows
           psversion: '7.4.0'
           arch: x64
@@ -80,6 +73,10 @@ jobs:
         - name: PS_7.4_x86_Windows
           psversion: '7.4.0'
           arch: x86
+          os: windows-latest
+        - name: PS_7.5_x64_Windows
+          psversion: '7.5.0'
+          arch: x64
           os: windows-latest
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog for ProcessEx
 
+## v0.6.0 - TBD
+
 ## v0.5.0 - 2024-01-05
 
 * Added support for `ProcessIntString` parameters accepting `uint` values as returned by WMI/CIM calls

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Documentation for this module and details on the cmdlets included can be found [
 
 These cmdlets have the following requirements
 
-* PowerShell v5.1 or newer
+* PowerShell v5.1 or 7.4+
 * .NET Framework 4.7.2+ or .NET Core+
 * Windows Server 2008 R2/Windows 7 or newer
 
@@ -29,9 +29,11 @@ You can install this module by running;
 
 ```powershell
 # Install for only the current user
+Install-PSResource -Name ProcessEx -Scope CurrentUser
 Install-Module -Name ProcessEx -Scope CurrentUser
 
 # Install for all users
+Install-PSResource -Name ProcessEx -Scope AllUsers
 Install-Module -Name ProcessEx -Scope AllUsers
 ```
 

--- a/manifest.psd1
+++ b/manifest.psd1
@@ -1,14 +1,14 @@
 @{
-    InvokeBuildVersion = '5.11.3'
-    PesterVersion = '5.6.1'
+    InvokeBuildVersion = '5.14.14'
+    PesterVersion = '5.7.1'
     BuildRequirements = @(
         @{
             ModuleName = 'Microsoft.PowerShell.PSResourceGet'
-            ModuleVersion = '1.0.6'
+            ModuleVersion = '1.1.1'
         }
         @{
             ModuleName = 'OpenAuthenticode'
-            RequiredVersion = '0.4.0'
+            RequiredVersion = '0.6.1'
         }
         @{
             ModuleName = 'platyPS'

--- a/module/ProcessEx.psd1
+++ b/module/ProcessEx.psd1
@@ -12,14 +12,14 @@
 
     # Script module or binary module file associated with this manifest.
     RootModule = if ($PSEdition -eq 'Core') {
-        'bin/net6.0-windows/ProcessEx.dll'
+        'bin/net8.0-windows/ProcessEx.dll'
     }
     else {
         'bin/net472/ProcessEx.dll'
     }
 
     # Version number of this module.
-    ModuleVersion = '0.5.0'
+    ModuleVersion = '0.6.0'
 
     # Supported PSEditions
     # CompatiblePSEditions = @()

--- a/src/ProcessEx/ProcessEx.csproj
+++ b/src/ProcessEx/ProcessEx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0-windows;net472</TargetFrameworks>
+    <TargetFrameworks>net8.0-windows;net472</TargetFrameworks>
     <LangVersion>12.0</LangVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <Nullable>enable</Nullable>

--- a/tools/InvokeBuild.ps1
+++ b/tools/InvokeBuild.ps1
@@ -68,17 +68,23 @@ task BuildDocs {
 }
 
 task Sign {
-    $vaultName = $env:AZURE_KEYVAULT_NAME
-    $vaultCert = $env:AZURE_KEYVAULT_CERT
-    if (-not $vaultName -or -not $vaultCert) {
+    $accountName = $env:AZURE_TS_NAME
+    $profileName = $env:AZURE_TS_PROFILE
+    $endpoint = $env:AZURE_TS_ENDPOINT
+    if (-not $accountName -or -not $profileName -or -not $endpoint) {
         return
     }
 
-    Write-Host "Authenticating with Azure KeyVault '$vaultName' for signing" -ForegroundColor Cyan
-    $key = Get-OpenAuthenticodeAzKey -Vault $vaultName -Certificate $vaultCert
+    Write-Host "Authenticating with Azure TrustedSigning $accountName $profileName for signing" -ForegroundColor Cyan
+    $keyParams = @{
+        AccountName = $accountName
+        ProfileName = $profileName
+        Endpoint = $endpoint
+    }
+    $key = Get-OpenAuthenticodeAzTrustedSigner @keyParams
     $signParams = @{
         Key = $key
-        TimeStampServer = 'http://timestamp.digicert.com'
+        TimeStampServer = 'http://timestamp.acs.microsoft.com'
     }
 
     $toSign = Get-ChildItem -LiteralPath $Manifest.ReleasePath -Recurse -ErrorAction SilentlyContinue |

--- a/tools/common.ps1
+++ b/tools/common.ps1
@@ -183,7 +183,7 @@ Function Assert-PowerShell {
         ARM64 { 'arm64' }
         default {
             $err = [ErrorRecord]::new(
-                [Exception]::new("Unsupported archecture requests '$_'"),
+                [Exception]::new("Unsupported architecture requests '$_'"),
                 "UnknownArch",
                 [ErrorCategory]::InvalidArgument,
                 $_


### PR DESCRIPTION
Updates the CI build deps, bumps to a new PowerShell 7 minimum and start using the Azure Trusted Signing service to sign the module.